### PR TITLE
feat: update status and requirements in bio sync plan

### DIFF
--- a/.ai/plan/feature-sponsors-bio-sync-1.md
+++ b/.ai/plan/feature-sponsors-bio-sync-1.md
@@ -2,15 +2,15 @@
 goal: Automate synchronization of SPONSORME.md content to GitHub Sponsors profile bio section
 version: 1.0
 date_created: 2025-08-12
-last_updated: 2025-08-12
+last_updated: 2025-08-21
 owner: Marcus R. Brown
-status: 'Planned'
+status: 'In Progress'
 tags: ['feature', 'automation', 'sponsors', 'github-api', 'bio-sync']
 ---
 
 # Automate GitHub Sponsors Profile Bio Synchronization
 
-![Status: Planned](https://img.shields.io/badge/status-Planned-blue)
+![Status: In Progress](https://img.shields.io/badge/status-In%20Progress-yellow)
 
 This plan implements automated synchronization of SPONSORME.md content to GitHub Sponsors profile bio section, ensuring consistent messaging across profile touchpoints. Building on the completed sponsors tracker automation, this creates a unified sponsor experience by mirroring compelling SPONSORME.md content (including dynamic progress tracking, tier recognition, and impact metrics) directly to the GitHub Sponsors profile bio. Implementation includes GitHub API integration for profile updates, content transformation from markdown to sponsor bio format, automated sync through existing 6-hour workflow, fallback mechanisms for API failures, and validation to ensure bio length limits and formatting requirements are met while preserving the engaging sponsor pitch and progress indicators.
 
@@ -18,9 +18,9 @@ This plan implements automated synchronization of SPONSORME.md content to GitHub
 
 - **REQ-001**: Synchronize SPONSORME.md content to GitHub Sponsors profile bio automatically
 - **REQ-002**: Preserve dynamic progress tracking, tier recognition, and impact metrics in bio format
-- **REQ-003**: Maintain consistent messaging across GitHub profile touchpoints
+- **REQ-003**: Maintain consistent messaging across GitHub Sponsors profile touchpoints
 - **REQ-004**: Transform markdown content to bio-appropriate plain text format
-- **REQ-005**: Validate bio length limits and formatting requirements (typically 160-500 characters for bio fields)
+- **REQ-005**: Validate sponsors profile bio length limits and formatting requirements
 - **REQ-006**: Integrate with existing 6-hour automated workflow schedule
 - **REQ-007**: Implement robust error handling and fallback mechanisms for API failures
 - **SEC-001**: Secure GitHub API authentication using existing token management
@@ -45,11 +45,11 @@ This plan implements automated synchronization of SPONSORME.md content to GitHub
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-001 | Research GitHub API endpoints for updating user/sponsor profile bio information | | |
-| TASK-002 | Investigate GitHub Sponsors API capabilities and limitations for profile updates | | |
-| TASK-003 | Determine authentication requirements and permissions needed for bio updates | | |
-| TASK-004 | Analyze bio field character limits, formatting restrictions, and content guidelines | | |
-| TASK-005 | Create proof-of-concept API calls to test bio update functionality | | |
+| TASK-001 | Research GitHub API endpoints for updating sponsor profile bio information | ✅ | 2025-08-21 |
+| TASK-002 | Investigate GitHub Sponsors API capabilities and limitations for profile updates | ✅ | 2025-08-21 |
+| TASK-003 | Determine authentication requirements and permissions needed for sponsor bio updates | | |
+| TASK-004 | Analyze GitHub Sponsors bio field character limits, formatting restrictions, and content guidelines | | |
+| TASK-005 | Create proof-of-concept API calls to test sponsor bio update functionality | | |
 | TASK-006 | Document API limitations, rate limits, and error response patterns | | |
 
 ### Implementation Phase 2: Content Transformation Engine
@@ -67,7 +67,7 @@ This plan implements automated synchronization of SPONSORME.md content to GitHub
 
 ### Implementation Phase 3: Bio Sync Service Implementation
 
-- GOAL-003: Build automated bio synchronization service with error handling
+- GOAL-003: Build automated sponsor profile bio synchronization service with error handling
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
@@ -86,9 +86,9 @@ This plan implements automated synchronization of SPONSORME.md content to GitHub
 |------|-------------|-----------|------|
 | TASK-019 | Update `.github/workflows/update-profile.yaml` to include bio sync step | | |
 | TASK-020 | Add bio sync to existing sponsor data update job sequence | | |
-| TASK-021 | Configure workflow permissions for GitHub API profile updates | | |
-| TASK-022 | Implement conditional bio sync based on SPONSORME.md content changes | | |
-| TASK-023 | Add workflow status reporting and error notifications for bio sync failures | | |
+| TASK-021 | Configure workflow permissions for GitHub API sponsor profile updates | | |
+| TASK-022 | Implement conditional sponsor bio sync based on SPONSORME.md content changes | | |
+| TASK-023 | Add workflow status reporting and error notifications for sponsor bio sync failures | | |
 | TASK-024 | Create manual trigger option for immediate bio sync when needed | | |
 
 ### Implementation Phase 5: Testing & Validation
@@ -98,11 +98,11 @@ This plan implements automated synchronization of SPONSORME.md content to GitHub
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
 | TASK-025 | Create unit tests for content transformation and validation functions | | |
-| TASK-026 | Develop integration tests for GitHub API bio update operations | | |
-| TASK-027 | Test bio sync with various SPONSORME.md content scenarios and edge cases | | |
-| TASK-028 | Validate bio length limits and formatting across different content types | | |
+| TASK-026 | Develop integration tests for GitHub API sponsor profile bio update operations | | |
+| TASK-027 | Test sponsor bio sync with various SPONSORME.md content scenarios and edge cases | | |
+| TASK-028 | Validate sponsor bio length limits and formatting across different content types | | |
 | TASK-029 | Test error handling and fallback mechanisms under various failure conditions | | |
-| TASK-030 | Perform end-to-end testing of automated workflow with bio sync enabled | | |
+| TASK-030 | Perform end-to-end testing of automated workflow with sponsor bio sync enabled | | |
 
 ## 3. Alternatives
 
@@ -114,7 +114,7 @@ This plan implements automated synchronization of SPONSORME.md content to GitHub
 
 ## 4. Dependencies
 
-- **DEP-001**: GitHub API access with sufficient permissions for profile/bio updates
+- **DEP-001**: GitHub API access with sufficient permissions for sponsor profile bio updates
 - **DEP-002**: Existing GitHub API client (`utils/github-api.ts`) and authentication system
 - **DEP-003**: Current sponsors tracking system (`scripts/fetch-sponsors-data.ts`)
 - **DEP-004**: SPONSORME.md template and content generation system


### PR DESCRIPTION
- Change last_updated date to 2025-08-21
- Update status from 'Planned' to 'In Progress'
- Clarify requirements for maintaining consistent messaging across GitHub Sponsors profile touchpoints
- Adjust validation requirements for sponsors profile bio length limits and formatting
- Revise task descriptions to specify 'sponsor' in bio updates