### PR TITLE
feat(ci): add Fro Bot agent workflow (PR review + maintenance + autoheal)

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -1,0 +1,648 @@
+---
+name: Fro Bot
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  discussion_comment:
+    types: [created]
+  issues:
+    types: [opened, edited]
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review, review_requested]
+  schedule:
+    # Autoheal at 04:30 UTC — staggered off other repos in the portfolio
+    # (mrbro.dev: 03:30, tokentoilet: 03:30, update-repo-settings: 02:55).
+    - cron: '30 4 * * *'
+    # Maintenance report at 16:30 UTC — 1h after mrbro.dev's 15:30 run.
+    - cron: '30 16 * * *'
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: Operation mode
+        type: choice
+        options:
+          - review
+          - maintenance
+          - autoheal
+        default: autoheal
+      prompt:
+        description: Custom prompt for review mode
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    fro-bot-${{
+      github.event.issue.number ||
+      github.event.pull_request.number ||
+      github.event.discussion.number ||
+      (github.event_name == 'schedule' && github.event.schedule) ||
+      github.run_id
+    }}
+  cancel-in-progress: false
+
+env:
+  # CUSTOMIZE: Tailor these prompts to the marcusrbrown profile repo's conventions and tech stack.
+  PR_REVIEW_PROMPT: |
+    You are reviewing a pull request for marcusrbrown/marcusrbrown — Marcus's
+    personal GitHub profile README repository. Pure TypeScript automation
+    (tsx, no build), template-driven content generation (README/BADGES/
+    SPONSORME/HIGHLIGHTS), and pnpm-managed dependencies. The README is
+    the public artifact; everything else exists to keep it accurate and
+    sponsor-conversion-optimized.
+
+    Read llms.txt for the project map before reviewing.
+
+    Focus your review on:
+
+    1. CORRECTNESS & EDGE CASES
+       - Logic errors, off-by-one, null/undefined paths
+       - GitHub API rate-limit handling and retry/fallback semantics
+       - Template-to-generated-output drift (templates/ vs README.md/
+         BADGES.md/SPONSORME.md/HIGHLIGHTS.md)
+       - Workflow gating (if: conditions, needs: chains, the skipped-needs
+         trap — finalize jobs that depend on conditional prepare jobs MUST
+         use !cancelled() to bypass the implicit success() guard)
+       - Schedule cadence collisions across the workflow set (update-profile
+         6h, update-repo-settings daily, fro-bot 04:30+16:30, cleanup-cache
+         weekly)
+
+    2. AUTOMATION INTEGRITY (elevated scrutiny)
+       - Silent failure paths: continue-on-error: true on local deterministic
+         steps is a red flag (use it only for external-API fetches with
+         clear fallback behavior)
+       - Workflow uses pinned SHAs for third-party actions, not floating tags
+       - Public-facing claims (README footer "Checked for updates every 6
+         hours") match actual behavior
+       - Generated content commits use the mrbro-bot[bot] identity, not a
+         human committer
+
+    3. SECURITY
+       - No secrets in logs, comments, or committed config
+       - Token scopes are minimum-necessary (read where possible,
+         write only where required)
+       - GitHub App tokens preferred over PATs for bot-authored commits
+       - No new external network calls without justification
+
+    4. TYPE SAFETY (TypeScript strict)
+       - No `any`, no `@ts-ignore`, no `@ts-expect-error`
+       - Discriminated unions over optional properties
+       - Parse, don't validate (Zod or equivalent for runtime data)
+       - Explicit return types on exported functions
+
+    5. STYLING & CONVENTIONS
+       - YAML extension: .yaml, not .yml
+       - Package manager: pnpm (not npm/yarn)
+       - Node.js: per .mise.toml / package.json engines
+       - Imports use TS path conventions; no CommonJS require/module.exports
+       - Test files in __tests__/ co-located by domain (badges, github-api,
+         logger, profile-analytics, sponsors)
+       - Markdown lint: rules in .markdownlint-cli2.yaml are authoritative
+
+    6. TESTING
+       - New/changed behavior must have vitest coverage in __tests__/
+       - Mock GitHub API in tests; never hit the real API
+       - Template generators should have round-trip tests
+         (template + data → expected output)
+
+    7. CONTENT INTEGRITY (profile-specific)
+       - README copy is current (no "Available for contracts starting Q1 2026"
+         claims when we're past that date; no "15+ years" claims that haven't
+         been refreshed in 2+ years)
+       - Dynamic embed URLs (shields.io, readme-typing-svg, github-readme-stats)
+         are functional and not blocked by external service deprecation
+       - SPONSORME.md tiers and goals match current GitHub Sponsors
+         configuration
+
+    Skip style nits — ESLint, Prettier, and markdownlint handle formatting.
+
+    Do NOT push commits, modify code, or create branches. Review only.
+    Use inline comments for file-specific issues. Reserve the review body
+    for the structured summary below.
+
+    You MUST structure your review using exactly these headings:
+    ## Verdict: [PASS | CONDITIONAL | REJECT]
+    CONDITIONAL = can merge after addressing the listed blocking issues.
+    ### Blocking issues
+    ### Non-blocking concerns
+    ### Missing tests
+    ### Risk assessment (LOW/MED/HIGH) + rationale
+    Evaluate likelihood of regression, automation outage, or content
+    publishing the wrong thing.
+    If a section has no items, write "None" under the heading.
+    Do not omit any heading.
+
+  MAINTENANCE_PROMPT: |
+    Perform daily repository maintenance for marcusrbrown/marcusrbrown — Marcus's
+    personal GitHub profile README repository. Pure TypeScript automation,
+    template-driven content generation, pnpm-managed.
+
+    Read llms.txt for the project map before analyzing.
+
+    Update a SINGLE perpetual issue titled "Daily Maintenance Report" in this
+    repository. There must be exactly one open maintenance issue at all times.
+
+    Finding the perpetual issue:
+    1. Search for an open issue titled "Daily Maintenance Report" (exact match).
+    2. If found, use that issue for all updates.
+    3. If not found, create a new issue with that exact title.
+    4. If the most recent matching issue is closed, reopen it instead of creating
+       a new one.
+
+    Perpetual issue hygiene: after selecting the single rolling issue,
+    search for any other open issues with the exact title "Daily Maintenance Report"
+    or "Daily Maintenance Report — YYYY-MM-DD" and close them with a brief
+    comment (e.g., "Consolidating into the perpetual maintenance issue.").
+    There must be exactly one open maintenance issue at all times.
+
+    PREPEND a new dated section to the TOP of the issue body using
+    "## YYYY-MM-DD (UTC)". Newest update is always first.
+
+    To keep the issue bounded: after prepending today's section, replace any
+    individual daily sections older than 14 days with a single
+    "## Historical Summary" section that lists only the count of prior runs
+    and any items that remained unresolved across those runs. If a Historical
+    Summary already exists, update it in place — do not create a second one.
+
+    When the issue body approaches 50,000 characters, archive older updates by
+    removing all but the 30 most recent daily sections, and note the archival in a
+    line like: "_[Archived N older updates on YYYY-MM-DD]_"
+
+    Include links only (no full content duplication). Keep it concise and actionable.
+    Flag items that appear in the stale list for the first time (not present in
+    the previous dated section) with a ★ marker.
+
+    Sections (in order):
+    - Summary metrics (issues opened since last run, currently open PRs, stale
+      issues/PRs count, main branch check status, security alerts if accessible,
+      last successful Update GitHub Profile run, last successful Update Repo
+      Settings run)
+    - Stale issues (no activity >30 days; recommend next step)
+    - Stale PRs (no activity >7 days; stale >14 days)
+    - Automation health (workflow runs over last 7 days: success/failure/
+      skipped counts per workflow; flag any workflow with >50% failure rate
+      or any workflow that has produced zero successful auto-generated
+      content commits in the last 7 days when it should have)
+    - Content freshness (flag README/SPONSORME claims that reference dates
+      now in the past, e.g., "available starting Q1 YYYY" where YYYY has
+      passed; flag years-of-experience claims older than 12 months)
+    - Cross-project intelligence (check marcusrbrown/mrbro.dev,
+      marcusrbrown/tokentoilet, marcusrbrown/vbs for adoptable maintenance
+      patterns, prompt evolution, or convention improvements that could
+      benefit this repo; include only if relevant findings exist)
+    - Recommended actions (bulleted checklist)
+    - Notes (use "data unavailable" for any inaccessible data source)
+
+    Do NOT comment on or modify individual issues/PRs (except for closing
+    duplicate maintenance issues per the perpetual issue hygiene exception
+    above). Do NOT apply labels. Do NOT open PRs. This run must update ONE
+    primary issue only (duplicate closures are permitted as the sole exception).
+
+  AUTOHEAL_PROMPT: |
+    Perform daily repository autohealing for marcusrbrown/marcusrbrown — Marcus's
+    personal GitHub profile README repository. Pure TypeScript automation,
+    template-driven content generation, pnpm-managed.
+
+    Read llms.txt for the project map before making changes.
+
+    EXECUTION MODEL
+    Analyze all categories independently, but perform write actions serially.
+    Do not keep multiple branches checked out at once. Complete one mutation,
+    return to a clean working tree, then continue.
+
+    DEDUPLICATION (applies to ALL categories)
+    Before creating any new PR or issue, search for an existing open
+    bot-authored PR/issue for the same root cause. Reuse or update the
+    existing item instead of creating a duplicate.
+
+    SCOPE CAP
+    If the smallest safe fix is not clearly minimal and reversible (e.g.,
+    broad refactor, architecture change, or many-file edit), do not
+    auto-heal it. Open or update an issue and log it under "Needs Human
+    Attention".
+
+    DEPENDENCY OWNERSHIP
+    Renovate owns routine dependency/version bumps (configured via
+    marcusrbrown/renovate-config preset). You may change dependency versions
+    only when remediating a confirmed security advisory (critical/high) or
+    repairing an existing security-update PR. Do not create non-security
+    version-bump PRs, and do not batch unrelated dependency changes into a
+    security fix. Do NOT modify package.json versions outside category 2
+    security remediation.
+
+    TRUSTED AUTHORS
+    Trusted PR authors for branch repair are Marcus and these automation bots:
+    - renovate[bot]
+    - dependabot[bot]
+    - mrbro-bot[bot]
+    - fro-bot
+
+    1. ERRORED PRs
+       Find open PRs with failing CI checks. Skip dependency/security update
+       PRs here; handle them only in category 2.
+       Only fix PRs whose head branch is in this repository, writable by
+       this token, and authored by a trusted source (repository
+       owner/collaborator with write access, or an approved automation bot
+       such as Renovate/Dependabot/mrbro-bot). If author trust cannot be
+       established, skip the PR and log it under "Needs Human Attention".
+       If the PR touches workflows, automation prompts, package-manager
+       config, lockfiles, or execution scripts, do not run project commands
+       from that branch. Skip it and log why.
+       For each fixable PR:
+       a. Check out the PR branch.
+       b. Read the failing check logs to diagnose the root cause.
+       c. Fix the issue (type errors, lint failures, test regressions,
+          template-generation failures).
+       d. Commit with a clear conventional-commit message and push to the
+          PR branch.
+       e. Comment on the PR explaining what failed and what was fixed.
+       f. Never modify .github/workflows/ or this prompt while repairing
+          an errored PR. If the failing run appears caused by the Fro Bot
+          workflow, skip the PR and log it under "Needs Human Attention".
+
+    2. SECURITY
+       Review Dependabot/Renovate alerts and open PRs for vulnerable deps.
+       - If a security update PR exists but has conflicts or failures,
+         fix and push to that PR branch.
+       - For unaddressed critical/high advisories with no existing PR,
+         create a new PR with the remediation.
+       - Do NOT bulk-update unrelated deps in a security PR.
+       If security advisory/alert data is unavailable to the token or CLI,
+       skip this category and note "security alerts unavailable" under
+       "Needs Human Attention". Do not guess.
+
+    3. CODE QUALITY & REPO HYGIENE
+       This category is primarily report-only. Focus on things only a
+       code-aware agent can catch:
+       - Run `pnpm lint` and report any failures (eslint + markdownlint).
+       - Run `pnpm test` and report any failures or coverage regressions.
+       - Run a template-vs-generated-content drift check: confirm
+         templates/README.tpl.md content matches README.md (the workflow
+         cp's the template to README.md, so they should match modulo the
+         generated SPONSORME/BADGES/HIGHLIGHTS that get linked in).
+       - Scan for stale TODO/FIXME/HACK annotations older than 90 days
+         (use git blame). Collect into a single issue or update an existing
+         "Stale TODOs" issue.
+       - Verify convention compliance:
+         * No `any`, no `@ts-ignore`, no `@ts-expect-error` in scripts/
+           utils/ types/
+         * No `continue-on-error: true` on deterministic local steps in
+           any workflow (only allowed on external-API fetches)
+         * All third-party actions in .github/workflows/ pinned to full
+           SHA, not floating tags
+         * YAML files use .yaml extension, not .yml
+       - Content freshness:
+         * Scan README.md and templates/README.tpl.md for date-bound claims
+           ("Available starting Q1 YYYY", "X+ years of experience", "Q1
+           2026" etc.) and flag any that are now stale relative to today's
+           date (UTC). Report findings; do not auto-edit (Marcus's voice).
+       - Workflow health: check the last 7 days of runs for each workflow.
+         Flag any workflow where >50% of expected runs failed, or where
+         scheduled runs produced zero successful auto-generated commits
+         when they should have (e.g., update-profile.yaml's
+         build/update-readme branch hasn't been pushed to in N days when
+         template content has changed). This caught a 1.5-year silent
+         outage in May 2026; we want it caught fast next time.
+       Report findings but put actual code fixes into category 4.
+
+       - Check that llms.txt accurately reflects the current directory
+         structure and file purposes. If drift is found, open an issue
+         (not a PR) describing the drift.
+
+    4. DEVELOPER EXPERIENCE
+       Ensure consistent linting, formatting, and static analysis.
+       Run `pnpm fix` (which combines `pnpm fix:eslint` + `pnpm fix:markdown`).
+       Fix any failures including convention violations found in category 3.
+       Open a PR for all fixes — never commit directly to the default
+       branch. Group related lint/format/convention fixes into a single PR.
+       Use a clear conventional-commit title like
+       `chore(lint): apply auto-fixes from autohealing run`.
+
+    5. QUALITY GATES VERIFICATION
+       Verify the project's quality gates pass on the default branch:
+       a. `pnpm lint` — 0 errors (warnings acceptable but reported)
+       b. `pnpm test` — all unit tests passing
+       c. `pnpm sponsors:update` — completes without error against cached
+          sponsor data (smoke test for template generation)
+       d. `pnpm badges:update` — completes without error against cached
+          badge data (smoke test for template generation)
+       e. `actionlint .github/workflows/*.yaml` — if actionlint is on PATH;
+          otherwise skip silently
+
+       For each failing gate:
+       - Identify the root cause from command output.
+       - If the fix is minimal and safe, include it in a category 4 PR.
+       - If the fix is complex, open an issue with diagnosis and
+         recommended approach.
+
+    6. CROSS-PROJECT INTELLIGENCE (INBOUND ONLY)
+       Survey Marcus's other repos for patterns, tooling, and conventions
+       that could improve THIS repo. The goal is inbound intelligence —
+       what can we learn from the portfolio to make this profile repo better?
+
+       Use `gh` CLI for all queries. Observation only — never modify
+       other repos.
+
+       Focus repos (check these every run; the list should evolve over
+       time — drop repos that consistently have nothing actionable, add
+       repos that become relevant):
+       - `marcusrbrown/mrbro.dev` — portfolio sibling; mode-based fro-bot
+         dispatch, perpetual issue hygiene, cross-project intelligence,
+         scope caps, dependency ownership
+       - `marcusrbrown/tokentoilet` — Fro Bot prompt evolution for
+         single-issue autohealing
+       - `marcusrbrown/vbs` — Vite/TypeScript patterns, CI safety
+       - `marcusrbrown/renovate-config` — dependency governance preset
+         evolution (this repo extends it)
+       - `marcusrbrown/.github` — shared repo conventions, org-level
+         workflows and templates
+       - `bfra-me/.github` — upstream of the update-repo-settings reusable
+         workflow this repo consumes
+       - `fro-bot/agent` — Fro Bot/OpenCode runtime capabilities and
+         release notes
+
+       For each focus repo, check:
+       a. Fro Bot version: compare `fro-bot/agent@` SHA if present.
+       b. CI patterns: any workflow improvements worth adopting?
+       c. Renovate config: any preset evolution worth adopting?
+       d. Prompt evolution: any new categories, hygiene rules, or scope
+          caps in sibling autoheal/maintenance prompts worth porting?
+       e. New conventions worth evaluating.
+
+       Keep findings actionable and specific to marcusrbrown/marcusrbrown.
+       Skip repos with nothing notable.
+
+       Hard boundaries:
+       - NEVER modify other repositories. Observation only.
+       - NEVER open PRs, issues, or comments in other repositories.
+       - NEVER clone or check out other repositories.
+       - All findings go into the perpetual summary issue in THIS
+         repository only.
+       - If a `gh` query fails for a repo, skip it and note why.
+
+    7. UPSTREAM MODERNIZATION WATCH (SUNDAYS UTC ONLY)
+       On Sundays UTC, review release notes for pinned upstreams:
+       - `fro-bot/agent` used by .github/workflows/fro-bot.yaml
+       - `actions/checkout`, `actions/create-github-app-token`,
+         `dorny/paths-filter`, `EndBug/add-and-commit`,
+         `peter-evans/create-pull-request`,
+         `pnpm/action-setup` used across workflows
+       - `bfra-me/.github` reusable workflow consumed by
+         update-repo-settings.yaml
+       - OpenCode/Fro Bot runtime docs relevant to opencode run, HTTP
+         mode, configured tools, skills, agents, hooks, and durable
+         session state
+
+       Identify new hardening or observability features worth adopting.
+       Do not bump versions or modify workflows in this category. Document
+       findings in the perpetual issue.
+
+       Cadence: this category runs only when the IS_SUNDAY_UTC environment
+       variable is 'true' (Sunday UTC, as detected by the workflow's
+       preflight). Before doing any category 7 work, read this variable.
+       On other days, skip entirely and omit the corresponding section
+       from the daily summary.
+
+    SINGLE ISSUE MANAGEMENT
+    Manage a SINGLE perpetual issue titled "Daily Autohealing Report".
+
+    Finding the perpetual issue:
+    1. Search for an open issue titled "Daily Autohealing Report" (exact match).
+    2. If found, use that issue for all updates.
+    3. If not found, create a new issue with that exact title.
+    4. If the most recent matching issue is closed, reopen it instead of
+       creating a new one.
+
+    Perpetual issue hygiene: search for any other open issues with titles
+    matching "Daily Autohealing Report" or "Daily Autohealing Report — YYYY-MM-DD"
+    and close them, keeping only the most recently updated one. If the most
+    recent issue has a dated title, rename it to the perpetual title. There
+    must be exactly one open autohealing issue at all times.
+
+    Updating the issue:
+    PREPEND a new dated section to the TOP of the issue body. Newest
+    update is always first. If a section has no rows, do not emit an
+    empty table — write "None." directly under that heading.
+
+    ## Update — YYYY-MM-DD (UTC)
+
+    ### Errored PRs
+    | PR | Failure | Fix | Status |
+    | --- | --- | --- | --- |
+    | #N | [root cause] | [what was fixed] | ✅ Fixed / ⚠️ Needs review / ⏭️ Skipped |
+
+    ### Security
+    | Advisory / PR | Severity | Action Taken |
+    | --- | --- | --- |
+    | [advisory or #N] | Critical/High/Medium | [fix pushed / PR created / skipped / unavailable] |
+
+    ### Code Quality & Repo Hygiene
+    | Check | Result | Action |
+    | --- | --- | --- |
+    | Lint | ✅ Clean / ⚠️ Warnings / ❌ Errors | [details or #N] |
+    | Tests | ✅ Pass / ❌ Fail | [details or #N] |
+    | Template drift | ✅ Aligned / ⚠️ Drift | [details or #N] |
+    | Stale TODOs | N found | [#N or None] |
+    | Convention drift | ✅ Clean / ⚠️ Issues | [details or #N] |
+    | Content freshness | ✅ Current / ⚠️ Stale claims | [details or issue ref] |
+    | Workflow health | ✅ Healthy / ⚠️ Degraded | [workflow names with stats] |
+    | llms.txt accuracy | ✅ Current / ⚠️ Drifted | [#N or None] |
+
+    ### Developer Experience
+    - [list of each PR or commit-sized fix with summary link]
+
+    ### Quality Gates
+    | Gate | Status | Details |
+    | --- | --- | --- |
+    | Lint | ✅ / ❌ | [error count or clean] |
+    | Tests | ✅ / ❌ | [pass/fail count] |
+    | sponsors:update smoke | ✅ / ❌ | [details] |
+    | badges:update smoke | ✅ / ❌ | [details] |
+    | actionlint | ✅ / ❌ / N/A | [details or "not on PATH"] |
+
+    ### Cross-Project Intelligence (Inbound)
+    | Repo | Finding | Actionable for marcusrbrown? | Priority |
+    | --- | --- | --- | --- |
+    | [repo] | [what they do that we don't] | [specific action or monitor] | High/Med/Low |
+
+    ### Upstream Modernization Watch
+    [Sunday-only section. On Sundays UTC, include findings or write "Scan
+    clean" if no actionable items. On other days, omit this entire
+    section from the daily update.]
+
+    ### Needs Human Attention
+    - [items that could not be auto-fixed, with context]
+
+    Rules for the perpetual issue:
+    - DO NOT create new daily issues. Always update the perpetual issue.
+    - DO NOT close the perpetual issue.
+    - ALWAYS prepend new updates to existing content (newest at top).
+    - When the issue body approaches 50,000 characters, archive older
+      updates by removing all but the 30 most recent daily sections, and
+      note the archival in a line like:
+      "_[Archived N older updates on YYYY-MM-DD]_"
+    - DO NOT comment on individual issues or PRs unless category 1 fixed
+      a failing PR (then ONLY post the fix-summary comment on that PR).
+
+    Hard boundaries:
+    - Never force-push, rewrite history, or delete branches.
+    - Never push directly to the default branch. Direct pushes are allowed
+      only to an existing non-default PR branch you are repairing under
+      category 1 or category 2.
+    - Never merge PRs, submit reviews/approvals, close/reopen PRs or
+      issues, or modify branch protection, EXCEPT for closing duplicate
+      "Daily Autohealing Report" or "Daily Maintenance Report" issues as
+      described in the perpetual issue hygiene section above. This
+      workflow may only push fixes, open/update PRs, open/update issues,
+      and comment on PRs when a fix was pushed.
+    - Never modify secrets, org settings, environments, or branch
+      protection.
+    - Never make checks pass by disabling tests, deleting failing
+      assertions, lowering coverage budgets, weakening lint rules, or
+      editing workflows/configuration only to suppress failures.
+    - If the smallest safe fix would weaken a guardrail or reduce
+      validation, skip it and log it under "Needs Human Attention".
+    - Cross-project intelligence (category 6) MUST NOT modify other repos.
+    - Upstream modernization watch (category 7) MUST NOT bump pinned
+      versions (Renovate-owned) or modify upstream repositories.
+    - Do not create multiple summary issues.
+    - Never edit Marcus's first-person content (README intro, bio,
+      SPONSORME copy). Report stale claims; don't rewrite them.
+
+    Project conventions (MUST follow for code changes):
+    - TypeScript strict mode: no `any`, no `@ts-ignore`, no `@ts-expect-error`
+    - Package manager: pnpm (not npm/yarn)
+    - YAML extension: .yaml, not .yml
+    - Test files in __tests__/, vitest, mock external APIs
+    - Workflow third-party actions pinned to full SHA
+    - No `continue-on-error: true` on deterministic local steps
+    - Generated content branch: build/update-readme (mrbro-bot[bot] committer)
+
+jobs:
+  fro-bot:
+    name: Fro Bot
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+      discussions: write
+    if: >-
+      (
+        github.event.pull_request == null ||
+        (
+          !github.event.pull_request.head.repo.fork &&
+          !endsWith(github.event.pull_request.user.login || '', '[bot]')
+        )
+      ) && (
+        (
+          github.event_name == 'issues' &&
+          !endsWith(github.event.issue.user.login || '', '[bot]') &&
+          (github.event.issue.user.login || '') != 'fro-bot' &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association || '')
+        ) ||
+        (
+          github.event_name == 'pull_request' &&
+          !endsWith(github.event.pull_request.user.login || '', '[bot]') &&
+          (github.event.pull_request.user.login || '') != 'fro-bot'
+        ) ||
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          (github.event_name == 'issue_comment' ||
+           github.event_name == 'pull_request_review_comment' ||
+           github.event_name == 'discussion_comment') &&
+          contains(github.event.comment.body || '', '@fro-bot') &&
+          (github.event.comment.user.login || '') != 'fro-bot' &&
+          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || '')
+        )
+      )
+    steps:
+      - name: Refuse fork PR heads from comment triggers
+        # issue_comment events carry no pull_request payload, so the
+        # job-level fork guard does not see comment-triggered checkouts
+        # of PR heads. Resolve the PR via the API and refuse fork heads
+        # before any code from that ref runs.
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        env:
+          GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          pr_number="${{ github.event.issue.number }}"
+          is_fork=$(gh api "repos/${{ github.repository }}/pulls/${pr_number}" --jq '.head.repo.fork // "unknown"')
+          if [ "$is_fork" != "false" ]; then
+            echo "::error::Refusing to check out fork PR head from comment trigger (PR #${pr_number}, fork=${is_fork})."
+            exit 1
+          fi
+
+      - name: Detect Sunday UTC for category 7 cadence
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        run: |
+          if [ "$(date -u +%u)" = "7" ]; then
+            echo "IS_SUNDAY_UTC=true" >> "$GITHUB_ENV"
+          else
+            echo "IS_SUNDAY_UTC=false" >> "$GITHUB_ENV"
+          fi
+
+      - name: Validate review mode inputs
+        if: github.event_name == 'workflow_dispatch' && inputs.mode == 'review'
+        env:
+          PROMPT: ${{ inputs.prompt }}
+        run: |
+          if [ -z "$PROMPT" ]; then
+            echo "::error::Review mode requires a custom prompt. Provide one via the 'prompt' input, or choose a different mode."
+            exit 1
+          fi
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # Check out PR code when:
+          # 1. Issue comment on PR: refs/pull/{number}/head
+          # 2. Direct PR event: pull_request.head.sha
+          # 3. Other events: default to workflow ref
+          ref: >-
+            ${{
+              (github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number))
+              || github.event.pull_request.head.sha
+              || ''
+            }}
+          # FRO_BOT_PAT scope: contents/issues/pull-requests/discussions
+          # write permissions, scoped to this repo only. No org/admin/
+          # secrets scopes.
+          token: ${{ secrets.FRO_BOT_PAT }}
+          persist-credentials: false
+
+      - name: Setup project
+        uses: ./.github/actions/setup
+
+      - name: Run Fro Bot
+        uses: fro-bot/agent@b928e79729f01b563feabee26a0525a3b48501a6 # v0.44.3
+        env:
+          OPENCODE_PROMPT_ARTIFACT: 'true'
+          IS_SUNDAY_UTC: ${{ env.IS_SUNDAY_UTC || 'false' }}
+          PROMPT: >-
+            ${{
+              (github.event_name == 'workflow_dispatch' && inputs.mode == 'review' && inputs.prompt)
+              || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance' && env.MAINTENANCE_PROMPT)
+              || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal' && env.AUTOHEAL_PROMPT)
+              || (github.event_name == 'workflow_dispatch' && !inputs.mode && env.AUTOHEAL_PROMPT)
+              || (github.event_name == 'schedule' && github.event.schedule == '30 16 * * *' && env.MAINTENANCE_PROMPT)
+              || (github.event_name == 'schedule' && github.event.schedule == '30 4 * * *' && env.AUTOHEAL_PROMPT)
+              || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
+              || ''
+            }}
+        with:
+          auth-json: ${{ secrets.OPENCODE_AUTH_JSON }}
+          github-token: ${{ secrets.FRO_BOT_PAT }}
+          model: ${{ vars.FRO_BOT_MODEL }}
+          omo-providers: ${{ secrets.OMO_PROVIDERS }}
+          opencode-config: ${{ secrets.OPENCODE_CONFIG }}
+          prompt: ${{ env.PROMPT }}
+          timeout: 0


### PR DESCRIPTION
## What

Adopts the Fro Bot agent pattern already running in [`marcusrbrown/mrbro.dev`](https://github.com/marcusrbrown/mrbro.dev/blob/main/.github/workflows/fro-bot.yaml) and [`marcusrbrown/tokentoilet`](https://github.com/marcusrbrown/tokentoilet/blob/main/.github/workflows/fro-bot.yaml), tailored to this repo's character: template-driven content generation, profile README integrity, and automation health monitoring.

Single new workflow at `.github/workflows/fro-bot.yaml` (no separate `fro-bot-autoheal.yaml` to merge — this repo had none). All three operating modes live in one file, dispatched by event + schedule + manual mode input.

## Three operating modes

### review (PR events)
Structured code review with required headings: PASS/CONDITIONAL/REJECT verdict, blocking issues, non-blocking concerns, missing tests, risk assessment. Prompt is tailored to this repo: template-vs-generated drift, workflow gating (including the **skipped-needs trap** that just bit us in #923), automation integrity (silent `continue-on-error` failures), and content freshness (date-bound claims like 'Q1 2026' that age out).

### maintenance (16:30 UTC daily, dispatch via mode=maintenance)
Updates a **single perpetual** `Daily Maintenance Report` issue with newest-on-top dated sections. Reports stale issues/PRs, **automation health** (last 7 days of workflow runs — flags any with >50% failure rate or scheduled workflows producing zero successful auto-commits when they should have), **content freshness** (date-bound README/SPONSORME claims now stale relative to today), and cross-project intelligence inbound from sibling repos. Bounded to 14-day rolling window with a `Historical Summary` rollup.

### autoheal (04:30 UTC daily, dispatch via mode=autoheal)
Updates a **single perpetual** `Daily Autohealing Report` issue. Seven categories: errored PRs, security advisories, code quality & repo hygiene, developer experience (lint/format PRs), quality gates verification (lint/test/sponsors:update/badges:update smoke), cross-project intelligence (inbound only), upstream modernization watch (Sundays UTC only). Strict scope cap + dependency ownership boundary (Renovate owns version bumps; autoheal only changes deps to remediate critical/high security advisories).

## Schedule cadence (staggered)

| Repo | Autoheal | Maintenance |
|---|---|---|
| marcusrbrown/marcusrbrown (this) | 04:30 UTC | 16:30 UTC |
| marcusrbrown/mrbro.dev | 03:30 UTC | 15:30 UTC |
| marcusrbrown/tokentoilet | 03:30 UTC | — |
| marcusrbrown/marcusrbrown (existing: update-repo-settings) | — | 02:55 UTC |
| marcusrbrown/marcusrbrown (existing: update-profile) | — | every 6h (0,6,12,18 UTC) |

60-minute spacing keeps Anthropic rate-limit usage from spiking on the same UTC minute across the portfolio.

## Security posture

- Mention triggers (`@fro-bot` in comments) restricted to OWNER/MEMBER/COLLABORATOR `author_association`.
- Bot-authored events explicitly filtered out (no self-triggering loops).
- Fork PR heads from `issue_comment` events refused before any checkout (matches tokentoilet's hardening).
- Workflow-level `permissions: contents: read`; job-level grants only what each step needs.
- `actions/checkout` uses `persist-credentials: false` to avoid leaking the PAT to subsequent steps.
- `fro-bot/agent` pinned to SHA `b928e79` (v0.44.3, latest as of 2026-05-20).
- `actions/checkout` pinned to SHA `de0fac2` (v6.0.2, matches existing workflows in this repo).

## Repo-specific prompt customizations (deltas from the example template)

The base template at [`fro-bot/agent#docs/examples/fro-bot.yaml`](https://github.com/fro-bot/agent/blob/main/docs/examples/fro-bot.yaml) ships read-only `SCHEDULE_PROMPT` (maintenance) only. This workflow extends it with:

- **Skipped-needs trap detection** in PR review (literal callout: workflows with `needs: [prepare]` where prepare has `if: github.event_name == 'pull_request'` MUST use `!cancelled()` — the bug that silently broke profile automation for 1.5 years and is being fixed in #923).
- **`continue-on-error` red-flag** as a review item (only allowed on external-API fetches, never on deterministic local steps).
- **Content freshness scan** as a maintenance + autoheal report category (flags 'Available starting Q1 YYYY' / 'X+ years of experience' / 'Q1 2026' patterns that are now past).
- **Workflow health monitor** (last 7 days of runs per workflow; flags scheduled workflows producing zero successful auto-commits when expected — catches silent skip outages fast).
- **Template-drift check** specific to the README/BADGES/SPONSORME/HIGHLIGHTS pipeline.
- **Cross-project intelligence focus list** evolved from siblings: mrbro.dev, tokentoilet, vbs, renovate-config, .github, **bfra-me/.github** (upstream of the update-repo-settings reusable workflow this repo consumes), fro-bot/agent.
- **Never-edit-Marcus's-first-person-voice** boundary in autoheal (report stale README/SPONSORME claims; don't rewrite them).
- **Smoke-test gates** specific to this repo: `sponsors:update` and `badges:update` must complete against cached data; `actionlint` if on PATH.

## Required secrets / config

| Name | Type | Status | Purpose |
|---|---|---|---|
| `FRO_BOT_PAT` | Secret | ✅ Already exists | PAT for @fro-bot identity on commits, issues, PRs |
| `OPENCODE_AUTH_JSON` | Secret | ❌ **Must be added before workflow can run** | LLM provider auth (e.g. `{"anthropic":{"apiKey":"sk-ant-..."}}`) |
| `OMO_PROVIDERS` | Secret | Optional | OpenCode provider overrides; falls back to defaults |
| `OPENCODE_CONFIG` | Secret | Optional | OpenCode runtime config override |
| `FRO_BOT_MODEL` | Variable | Optional | Model override (e.g. `anthropic/claude-opus-4.7`); falls back to fro-bot default |

The optional secrets/var are soft — the workflow YAML references them but `fro-bot/agent` falls back to its own defaults when absent.

## Verification

- `actionlint`: clean
- `pnpm lint`: 0 errors (4 pre-existing SPONSORME warnings unrelated to this PR)
- `pnpm test`: not run for this PR (no test code added)
- Workflow file: 648 lines, single new file, no existing files modified

## After merge

1. Add the `OPENCODE_AUTH_JSON` secret (required).
2. Manually trigger via Actions UI → `Fro Bot` → `Run workflow` → mode=`autoheal` to validate end-to-end.
3. The 04:30 UTC autoheal + 16:30 UTC maintenance schedules will then run daily without further intervention.
4. The first run will create the two perpetual issues (`Daily Autohealing Report`, `Daily Maintenance Report`); subsequent runs prepend dated sections instead of creating new issues.

## Sequencing note

This PR is intended to land **before** #923 (the profile-automation restoration PR) so that Fro Bot can review #923. After this merges, push a refresh to #923's branch (or add a trivial commit) to retrigger Fro Bot's review on it.