### PR TITLE
chore: clean up llms.txt drift and replace any types with precise interfaces

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,7 @@ This repository serves as Marcus R. Brown's GitHub profile page, displaying his 
 - [A/B Testing Framework](scripts/ab-testing-framework.ts): Framework for testing different content variations
 - [Content Performance Tracking](scripts/content-performance-tracking.ts): Analytics and performance monitoring for profile content
 - [Mobile Responsiveness Tester](scripts/mobile-responsiveness-tester.ts): Testing tool for mobile device compatibility
+- [Profile Analytics](scripts/profile-analytics.ts): GitHub-native traffic and contribution analytics for the profile repository
 
 ## Development
 
@@ -52,6 +53,7 @@ This repository serves as Marcus R. Brown's GitHub profile page, displaying his 
 - [Shield.io Client](utils/shield-io-client.ts): Client for Shield.io badge service API
 - [Sponsor Type Definitions](types/sponsors.ts): TypeScript type definitions for sponsor data structures
 - [Badge Type Definitions](types/badges.ts): TypeScript type definitions for badge data structures
+- [Analytics Type Definitions](types/analytics.ts): TypeScript type definitions for GitHub traffic and contribution analytics
 
 ## Documentation
 
@@ -67,4 +69,6 @@ This repository serves as Marcus R. Brown's GitHub profile page, displaying his 
 - [GitHub API Tests](__tests__/github-api.test.ts): Unit tests for GitHub API utilities
 - [Logger Tests](__tests__/logger.test.ts): Unit tests for logging utilities
 - [Sponsor Tests](__tests__/sponsors.test.ts): Unit tests for sponsor data processing
+- [Profile Analytics Tests](__tests__/profile-analytics.test.ts): Unit tests for profile analytics CLI, retry/cache/trend logic
+- [Update Sponsors Resilience Tests](__tests__/update-sponsors-resilience.test.ts): Resilience tests for sponsor data loading fallback paths
 - [Prettier Configuration](.prettierignore): Code formatting exclusions and configuration references

--- a/scripts/content-performance-tracking.ts
+++ b/scripts/content-performance-tracking.ts
@@ -14,6 +14,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import process from 'node:process'
 import type {
+  ContentPerformance,
   ConversionEvent,
   ConversionMetrics,
   PerformanceReport,
@@ -312,15 +313,12 @@ export class ContentPerformanceTracker {
   /**
    * Analyze content performance based on events
    */
-  private analyzeContentPerformance(events: ConversionEvent[]): Record<string, any> {
-    // Group events by content type/source if available
-    const performance: Record<string, any> = {
+  private analyzeContentPerformance(events: ConversionEvent[]): ContentPerformance {
+    return {
       totalEngagement: events.length,
       conversionEvents: events.filter(e => e.type === 'sponsor_acquired').length,
       viewEvents: events.filter(e => e.type === 'profile_view').length,
     }
-
-    return performance
   }
 
   /**

--- a/types/sponsors.ts
+++ b/types/sponsors.ts
@@ -114,7 +114,7 @@ export interface ConversionEvent {
     value?: number
     source?: string
     sponsors?: string[]
-    [key: string]: any
+    [key: string]: unknown
   }
 }
 
@@ -171,6 +171,15 @@ export interface SponsorAcquisitionData {
 }
 
 /**
+ * Content performance analysis shape returned by analyzeContentPerformance
+ */
+export interface ContentPerformance {
+  totalEngagement: number
+  conversionEvents: number
+  viewEvents: number
+}
+
+/**
  * Performance report for sponsor pitch optimization
  */
 export interface PerformanceReport {
@@ -189,7 +198,7 @@ export interface PerformanceReport {
     totalFunding: number
   }
   /** Content performance analysis */
-  contentPerformance: Record<string, any>
+  contentPerformance: ContentPerformance
   /** Optimization recommendations */
   recommendations: string[]
 }


### PR DESCRIPTION
## What

Closes two items flagged by autoheal report #926:

### 1. llms.txt drift — 4 missing files added to manifest

| File | Section |
|---|---|
| `scripts/profile-analytics.ts` | Automation & Testing |
| `types/analytics.ts` | Utilities & Types |
| `__tests__/profile-analytics.test.ts` | Optional |
| `__tests__/update-sponsors-resilience.test.ts` | Optional |

### 2. `any` → precise types (4 instances)

- `types/sponsors.ts` line 117: `[key: string]: any` → `[key: string]: unknown` in `ConversionEvent.data`
- `types/sponsors.ts` line 192: `contentPerformance: Record<string, any>` → `contentPerformance: ContentPerformance` (new named interface)
- `scripts/content-performance-tracking.ts` lines 315/317: both `Record<string, any>` annotations on `analyzeContentPerformance` replaced by returning `ContentPerformance` directly

The `ContentPerformance` interface is extracted into `types/sponsors.ts` and imported in the script — single source of truth.

## Why

Autoheal report #926 flagged these as drift/quality issues. The `any` replacements follow the "parse, don't validate" principle — consumers of `ConversionEvent.data` must now narrow unknown values before use, and `PerformanceReport.contentPerformance` is now structurally precise.

## Verification

- `pnpm lint`: ✅ 0 errors (4 pre-existing markdown warnings unrelated to this PR)
- `pnpm test`: ✅ 72/72 tests pass
- `grep -nE ': any[^a-zA-Z_]|<any[^a-zA-Z_]|as any|Record<[^,]+,\s*any\s*>' scripts/ utils/ types/ -r`: ✅ 0 matches
- `git diff main --stat`: 3 files changed (llms.txt, scripts/content-performance-tracking.ts, types/sponsors.ts)