### PR TITLE
chore(content): rewrite SPONSORME — 670 lines of marketing sludge → 108 lines of honest pitch

### DIFF
--- a/BADGES.md
+++ b/BADGES.md
@@ -10,7 +10,7 @@
 
 <p align="center">
 
-![TypeScript badge](https://img.shields.io/badge/TypeScript-24.12.4-007ACC?style=for-the-badge&labelColor=656d76&logo=typescript) ![JavaScript badge](https://img.shields.io/badge/JavaScript-primary-F7DF1E?style=flat-square&labelColor=656d76&logo=javascript) ![Python badge](https://img.shields.io/badge/Python-primary-3776AB?style=flat-square&labelColor=2ea043&logo=python) ![Go badge](https://img.shields.io/badge/Go-primary-00ADD8?style=flat-square&labelColor=2ea043&logo=go)
+![TypeScript badge](https://img.shields.io/badge/TypeScript-24.12.4-007ACC?style=for-the-badge&labelColor=656d76&logo=typescript) ![JavaScript badge](https://img.shields.io/badge/JavaScript-primary-F7DF1E?style=flat-square&labelColor=2ea043&logo=javascript) ![Python badge](https://img.shields.io/badge/Python-primary-3776AB?style=flat-square&labelColor=2ea043&logo=python) ![Go badge](https://img.shields.io/badge/Go-primary-00ADD8?style=flat-square&labelColor=2ea043&logo=go)
 
 </p>
 

--- a/SPONSORME.md
+++ b/SPONSORME.md
@@ -1,684 +1,80 @@
 <!--markdownlint-disable-->
 
-## 🛠️ The Automation Expert Who Builds the Tools That Save You Hours Every Week
+## Sponsor Marcus R. Brown
 
-### Supporting the developer who fixes what's broken in the ecosystem you depend on
-
-I'm Marcus R. Brown, and I create developer productivity tools, solve complex automation challenges, and contribute meaningfully to the open source projects that power your daily work. When you sponsor me, you're not just funding individual projects—you're unlocking a **force multiplier** that amplifies your impact across the entire developer community.
+I maintain open source developer tooling. If you use what I build, sponsorship keeps me funded to keep it working.
 
 <div align="center">
 
-**🎯 [Sponsor Marcus →](https://github.com/sponsors/marcusrbrown)**
+**[Sponsor on GitHub →](https://github.com/sponsors/marcusrbrown)**
 
-</div>
-
-<div align="center">
-<small><em>Join 1 developers already investing in productivity and ecosystem growth</em></small>
-</div>
-
----
-
-### 💡 Why Sponsor Marcus? Clear Value, Proven Impact
-
-<br />
-
-> #### 🛠️ **Advanced Developer Automation & Productivity**
->
-> I build sophisticated automation systems that eliminate repetitive tasks and streamline development workflows. From GitHub sponsor tracking to badge synchronization, my tools save developers significant time every week.
->
-> #### 🔧 **Active Problem-Solver Across the Ecosystem**
->
-> I don't just maintain my own projects—I actively [add features][], [participate in bounties][], and [fix bugs][] across the open source ecosystem. If something's broken and affecting the community, I step in to solve it.
->
-> #### 🌟 **Force Multiplier Effect**
->
-> Your sponsorship creates a ripple effect: I reinvest sponsor support to back other innovative developers, creating a sustainable cycle that amplifies your contribution throughout the community.
->
-> #### 👨‍👩‍👧‍👦 **Family-Driven Mission with Professional Quality**
->
-> As a father of five balancing family priorities with meaningful contribution, I bring both authentic purpose and professional development standards to everything I build.
-
-<div align="center">
-
-**🌟 [See Sponsorship Tiers →](https://github.com/sponsors/marcusrbrown)**
+<small><em>Active sponsors: 0</em> · Goal: 15 monthly sponsors (0.0%)</small>
 
 </div>
 
 ---
 
-## 🎯 Sponsor Benefits: Clear Value for Every Contribution Level
+### What I work on
 
-### 🥉 Bronze Tier ($1-4): Community Recognition & Appreciation
+Principal engineer & architect, shipping since 2004. Current focus: agent-native systems, developer tooling, and open source maintenance.
 
-**Perfect for expressing gratitude and joining the mission with minimal commitment**
+- **[bfra-me/works](https://github.com/bfra-me/works)** — TypeScript tooling configs (ESLint, Prettier, tsconfig presets) used across my projects and a handful of others
+- **[marcusrbrown/systematic](https://github.com/marcusrbrown/systematic)** — Structured engineering workflows for OpenCode
+- **[fro-bot/agent](https://github.com/fro-bot/agent)** — Background-agent harness for delegated work in OpenCode
+- **[ps2dev/ps2sdk](https://github.com/ps2dev/ps2sdk)** — Long-term contributor & maintainer (PlayStation 2 homebrew SDK, 1.1k+ stars)
+- **[marcusrbrown/.dotfiles](https://github.com/marcusrbrown/.dotfiles)** — Reproducible dev environment configuration
 
-- ✅ **Public Recognition**: Your profile featured as a valued community supporter
-- ✅ **Monthly Updates**: Stay informed about project progress and new developments
-- ✅ **Community Membership**: Join a growing network of productivity-focused developers
-- ✅ **Force Multiplier Impact**: Your contribution helps sponsor other innovative developers
+Plus issue triage, PRs, and reviews across the projects I depend on.
 
-**ROI**: Every dollar amplifies across multiple projects and developers in the ecosystem
+### What sponsorship funds
 
----
+- Time on the tooling above instead of squeezing it between contracts
+- Faster bug-fix turnaround on the projects sponsors actually use
+- Continued contribution to the upstream projects I rely on
 
-### 🥈 Silver Tier ($5-9): Early Access & Development Insights
+### Tiers
 
-**Ideal for developers who regularly use automation tools and want to stay ahead**
-
-- ✅ **Everything in Bronze**, plus:
-- ⭐ **Early Access**: First look at new productivity tools and automation systems
-- ⭐ **Development Insights**: Behind-the-scenes content on problem-solving approaches
-- ⭐ **Priority Recognition**: Enhanced visibility in sponsor showcases
-- ⭐ **Technical Content**: Exclusive tips on advanced development practices
-
-**ROI**: Save 2-3 hours monthly through early access to time-saving tools and techniques
-
----
-
-### 🥇 Gold Tier ($10-24): Direct Communication & Priority Support
-
-**Perfect for professional developers seeking networking and technical guidance**
-
-- ✅ **Everything in Silver**, plus:
-- 🌟 **Direct Communication**: Monthly Q&A access for technical questions
-- 🌟 **Feature Input**: Priority consideration for tool features and improvements
-- 🌟 **Professional Networking**: Connect with other Gold+ sponsors in developer community
-- 🌟 **Custom Insights**: Personalized automation recommendations for your workflow
-
-**ROI**: Professional networking value plus personalized efficiency improvements worth 10x the investment
-
----
-
-### 🏆 Platinum Tier ($25-99): Expert Consultation & Strategic Partnership
-
-**Ideal for senior developers and companies seeking strategic technical guidance**
-
-- ✅ **Everything in Gold**, plus:
-- 💎 **Monthly Consultation**: 30-minute monthly video call for technical strategy and guidance
-- 💎 **Custom Content**: Personalized automation scripts and workflow optimization recommendations
-- 💎 **Strategic Partnership**: Input on major technical decisions and project direction
-- 💎 **Executive Recognition**: Featured prominently as a key strategic partner
-- 💎 **Priority Development**: Custom feature development for high-value requests
-
-**ROI**: Executive-level technical guidance worth $200+ monthly plus strategic networking opportunities
-
----
-
-### 💎 Diamond Tier ($100+): Premium Partnership & Custom Development
-
-**For organizations and individuals seeking comprehensive technical partnership**
-
-- ✅ **Everything in Platinum**, plus:
-- 🔥 **Dedicated Support**: Priority response to technical questions and challenges
-- 🔥 **Custom Development**: Quarterly custom tool/script development for your specific needs
-- 🔥 **Advisory Partnership**: Ongoing strategic technical advisory and consultation
-- 🔥 **Exclusive Access**: Early access to all tools, private Discord channel, direct messaging
-- 🔥 **Recognition & Branding**: Logo placement and premium sponsor showcase across projects
-- 🔥 **Speaking Opportunities**: Conference/meetup speaking collaboration and content partnership
-
-**ROI**: Comprehensive technical partnership delivering custom solutions worth $1000+ annually
+GitHub Sponsors lets you pick any amount. Three rough buckets if you want a reference point:
 
 <div align="center">
 
-**🚀 [Choose Your Tier →](https://github.com/sponsors/marcusrbrown)**
+| Tier               | Amount      | What you get                                                                                         |
+| :----------------- | :---------- | :--------------------------------------------------------------------------------------------------- |
+| **🥉 Bronze**      | $1 – $4/mo  | Listed below as a supporter. Helps cover hosting & domains.                                          |
+| **🥈 Silver**      | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time.                                             |
+| **🥇 Gold**        | $25+/mo     | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest.     |
 
 </div>
 
----
-
-## 👨‍👩‍👧‍👦 My Story: From Childhood Passion to Force Multiplier Mission
-
-### The Fix-It Mentality That Drives Everything
-
-> "If I see something broke, I fix it. If it can be automated, I automate it. If it helps developers, I share it."
-
-I've been passionate about open source software since I taught myself programming as a kid. What started as curiosity about how things work has evolved into a deep commitment to building tools that make other developers' lives better.
-
-Today, I live in ☀ Arizona with my five wonderful children, balancing the joys and challenges of family life with meaningful contribution to the developer community. This isn't a side hustle or personal project—it's my authentic mission to create sustainable value in the ecosystem that has given me so much.
-
-### Why Family Balance Creates Better Tools
-
-As a father of five, I understand the importance of:
-
-- **Efficient workflows** that maximize productive time when you have it
-- **Reliable tools** that don't break when you need them most
-- **Sustainable practices** that respect both work and family commitments
-- **Quality over quantity** in everything I build and contribute
-
-This family perspective brings authenticity and purpose to my work. I'm not building for vanity metrics or quick wins—I'm focused on creating genuine value that improves how developers work and live.
-
-### The Force Multiplier Vision
-
-Your sponsorship does more than fund individual projects. It creates a **force multiplier effect** where:
-
-1. **Your investment** supports advanced automation and productivity tools
-2. **Time savings** from my tools benefit thousands of developers daily
-3. **Sponsor reinvestment** flows to other innovative developers and projects
-4. **Community growth** creates sustainable ecosystem improvements for everyone
-
-When you sponsor me, you're not just supporting one developer—you're investing in a philosophy of mutual support and ecosystem sustainability that amplifies your impact across the entire community.
-
-<div align="center">
-
-**💝 [Join the Mission →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
+I'm not running a consulting business through GitHub Sponsors. No monthly calls promised, no custom dev work, no logo placement. If you need any of that, [contact me directly](https://github.com/marcusrbrown).
 
 <!-- START:sponsor-tracker -->
-<!-- This section will be dynamically populated with sponsor data -->
+<!-- This section is dynamically populated with sponsor data -->
 
-## 📊 Progress Tracker
+### Funding goal
 
-### 🎯 Funding Goals
-
-#### Coffee Fund
-
-Support my daily coding fuel ☕
-
-**Target:** $50/month • **Progress:** 2.0%
-
-```
-░░░░░░░░░░░░░░░░░░░░ 2.0%
-```
-
-<div align="right"><small><em>$1 of $50 monthly goal</em></small></div>
-
-#### Open Source Maintenance
-
-Dedicated time for maintaining and improving open source projects
-
-**Target:** $200/month • **Progress:** 1.0%
-
-```
-░░░░░░░░░░░░░░░░░░░░ 1.0%
-```
-
-<div align="right"><small><em>$2 of $200 monthly goal</em></small></div>
-
-#### Development Tools & Services
-
-Premium tools and cloud services for better development experience
-
-**Target:** $100/month • **Progress:** 1.0%
-
-```
-░░░░░░░░░░░░░░░░░░░░ 1.0%
-```
-
-<div align="right"><small><em>$1 of $100 monthly goal</em></small></div>
-
-### 📈 Monthly Funding Overview
+*No active funding goals at this time.*
 
 <div align="center">
 
-| **Total Monthly Support** | **Active Goals** | **Overall Progress** |
-| :-----------------------: | :--------------: | :------------------: |
-|          **$1**           |      **3**       |       **1.3%**       |
+| **Total Monthly Support** |    **Active Goals**    |       **Overall Progress**       |
+| :-----------------------: | :--------------------: | :------------------------------: |
+| **$0** | **0** | **0.0%** |
 
 </div>
 
-_Last updated: May 24, 2026_
+<small><em>Last updated: May 23, 2026</em></small>
 
-## 🙏 Sponsor Recognition
+### Supporters
 
-### 💎 Our Amazing Supporters
-
-#### 🥉 Bronze Sponsors
-
-<div align="center">
-
-<a href="https://github.com/thejustinwalsh" title="Justin Walsh">
-  <img src="https://avatars.githubusercontent.com/u/72912?u=f8701578b439d99673c3acbc30954c42d27146dd&v=4" width="60" height="60" alt="Justin Walsh" style="border-radius: 50%; margin: 5px;">
-</a>
-
-</div>
-
-<div align="center">
-<small><em>1 supporters contributing $1+ per month</em></small>
-</div>
-
-### 🎉 Special Thanks
-
-<div align="center">
-<em>Thank you to all 1 sponsors for your incredible support!</em><br>
-<small>Your contributions help maintain and improve open source projects that benefit the entire community.</small>
-</div>
-
----
-
-<div align="center">
-<strong>💝 Want to join these amazing people?</strong><br>
-<a href="https://github.com/sponsors/marcusrbrown">
-  <img src="https://img.shields.io/github/sponsors/marcusrbrown?style=for-the-badge&logo=github-sponsors" alt="Sponsor @marcusrbrown">
-</a>
-</div>
-
-## 📈 Impact Metrics
-
-### 🎯 Community Impact
-
-<div align="center">
-
-| Metric                       |      Value       |
-| :--------------------------- | :--------------: |
-| **💰 Total Monthly Support** |      **$1**      |
-| **👥 Active Sponsors**       |      **1**       |
-| **🏆 Highest Tier**          |    **Bronze**    |
-| **📊 Average Contribution**  |      **$1**      |
-| **📅 Supporting Since**      | **May 24, 2026** |
-
-</div>
-
-### 🏅 Tier Breakdown
-
-<div align="center">
-
-| Tier                      | Count | Monthly Total | Percentage |
-| :------------------------ | :---: | :-----------: | :--------: |
-| 💎 **Diamond** ($100+)    |   0   |      $0       |    0.0%    |
-| 🏆 **Platinum** ($25-$99) |   0   |      $0       |    0.0%    |
-| 🥇 **Gold** ($10-$24)     |   0   |      $0       |    0.0%    |
-| 🥈 **Silver** ($5-$9)     |   0   |      $0       |    0.0%    |
-| 🥉 **Bronze** ($1-$4)     |   1   |      $1       |   100.0%   |
-
-</div>
-
-### 💫 Growth & Impact
-
-- **📈 Monthly Growth:** +0
-- **🎯 Goal Achievement:** 0 of funding goals reached
-- **🚀 Project Velocity:** Sponsor support enables 10+ active projects
-- **🌟 Community Reach:** Contributing to 1,000+ developers worldwide
-
-<div align="center">
-<small><em>Statistics last updated: May 24, 2026</em></small>
-</div>
+*No sponsors to display at this time. Be the first to support this project!*
 
 <!-- END:sponsor-tracker -->
 
-## Proven Track Record: Project Portfolio & Community Impact
-
-### 🛠️ Signature Projects & Contributions
-
-> #### GitHub Sponsors Automation System
->
-> **Impact**: Comprehensive sponsor tracking and recognition system used by OSS maintainers **Technologies**: TypeScript, GitHub API, Dynamic template generation **Community Benefit**: Streamlines sponsor management for open source projects
->
-> #### Developer Productivity Tools Suite
->
-> **Impact**: Badge synchronization, profile automation, and development workflow optimization **Technologies**: Advanced GitHub Actions, API integrations, automated workflows **Community Benefit**: Saves developers 5+ hours weekly on repetitive tasks
->
-> #### Cross-Project Ecosystem Contributions
->
-> **Impact**: Active contributor to textproto-grammar, vscode-markdownlint, and 20+ OSS projects **Technologies**: Language servers, VS Code extensions, parsing libraries **Community Benefit**: Bug fixes and features used by thousands of developers daily
-
-### 📊 Community Reach & Developer Ecosystem Impact
-
-<div align="center">
-
-| **Ecosystem Metric**      | **Impact Scale**             | **Community Value**             |
-| :------------------------ | :--------------------------- | :------------------------------ |
-| **🔧 Active Projects**    | **15+ maintained**           | **Tools used by 10,000+ devs**  |
-| **🐛 Issues Resolved**    | **500+ across projects**     | **Developer friction reduced**  |
-| **⚡ Automation Created** | **Hours saved weekly**       | **Productivity multiplied**     |
-| **🤝 OSS Contributions**  | **Multi-year consistency**   | **Ecosystem strengthened**      |
-| **Problem-Solving**       | **Cross-platform expertise** | **Universal developer benefit** |
-
-</div>
-
-### 🎯 Technical Authority & Expertise Validation
-
-**Advanced Technical Skills:**
-
-- **TypeScript & Node.js**: Expert-level automation and API integration development
-- **GitHub API Mastery**: Comprehensive understanding of GitHub's ecosystem and capabilities
-- **DevOps & Automation**: Sophisticated CI/CD pipelines and workflow optimization
-- **Open Source Strategy**: Proven track record of meaningful community contribution
-
-**Professional Development Standards:**
-
-- **External Configuration Strategy**: All tooling configs extend from `@bfra.me/*` packages
-- **Quality Assurance**: Comprehensive testing, linting, and type checking across all projects
-- **Documentation Excellence**: Clear, maintainable codebases with professional documentation
-- **Consistency & Reliability**: Multi-year track record of consistent, quality contributions
-
-**Years of Experience:**
-
-- **15+ Years**: Professional software development and system architecture
-- **10+ Years**: Active open source contribution and community involvement
-- **5+ Years**: Advanced automation and developer productivity specialization
-- **Continuous Learning**: Staying current with evolving technologies and best practices
-
----
-
-## 💬 Community Trust & Recognition
-
-### 🌟 Sponsor Testimonials
-
-<!-- TESTIMONIAL_SECTION_START -->
-<!-- This section will be populated with sponsor feedback as it becomes available -->
-
-> #### Future Testimonials
->
-> _This section will feature testimonials from sponsors as they share their experiences and the value they've received from supporting Marcus's work._
->
-> **Testimonial Categories:**
->
-> - **Tool Impact**: How Marcus's automation saves time and improves workflows
-> - **Community Value**: The broader benefit of supporting ecosystem development
-> - **Professional Quality**: Recognition of technical excellence and reliability
-> - **Force Multiplier**: Stories of how sponsorship creates ripple effects
-
-<!-- TESTIMONIAL_SECTION_END -->
-
-### 🎯 Trust Signals & Community Standing
-
-**GitHub Profile Statistics:**
-
-- **📈 Contribution Graph**: Consistent daily contributions across multiple years
-- **⭐ Repository Impact**: Projects with measurable adoption and community usage
-- **🤝 Collaboration**: Active participation in issues, PRs, and community discussions
-- **🏆 Profile Recognition**: GitHub activity demonstrating long-term commitment
-
-**Open Source Community Involvement:**
-
-- **🌍 Cross-Project Contributions**: Active in diverse projects beyond personal repositories
-- **🔧 Maintenance Leadership**: Maintaining critical tools used by developer community
-- **💡 Innovation**: Creating new solutions for common developer productivity challenges
-- **🎯 Problem-Focused**: Consistent track record of identifying and solving real developer pain points
-
-**Professional Network & Recognition:**
-
-- **👥 Developer Community**: Active engagement with fellow open source contributors
-- **📱 Platform Presence**: Authentic participation in developer community discussions
-- **🎤 Knowledge Sharing**: Contributing expertise through code, documentation, and community interaction
-- **🏅 Peer Recognition**: Respected contributor in TypeScript, automation, and developer tools communities
-
----
-
-## 🎓 Authority & Thought Leadership
-
-### 💡 Innovation & Technical Leadership
-
-**Automation Philosophy:**
-
-> "If I see something broke, I fix it. If it can be automated, I automate it. If it helps developers, I share it."
-
-**Key Innovation Areas:**
-
-- **Developer Productivity**: Creating tools that eliminate repetitive tasks and streamline workflows
-- **GitHub Ecosystem**: Deep expertise in GitHub API, Actions, and platform optimization
-- **Open Source Strategy**: Proven approach to sustainable project maintenance and community building
-- **Force Multiplier Approach**: Understanding how individual contributions create ecosystem-wide benefits
-
-**Technical Thought Leadership:**
-
-- **External Configuration Strategy**: Pioneering approach to maintainable tooling configurations
-- **Automation-First Development**: Implementing comprehensive automation across all development workflows
-- **Community-Driven Quality**: Balancing individual productivity with broader ecosystem contribution
-- **Sustainable Open Source**: Creating systems that support long-term project health and growth
-
-### 🎯 Problem-Solving Expertise
-
-**Proven Approach:**
-
-1. **Identify Real Problems**: Focus on genuine developer pain points with measurable impact
-2. **Create Robust Solutions**: Build reliable, well-tested tools that solve problems completely
-3. **Share & Document**: Make solutions accessible with clear documentation and examples
-4. **Maintain & Improve**: Provide ongoing support and evolution based on community feedback
-5. **Amplify Impact**: Use successful solutions to enable broader community contributions
-
-**Areas of Expertise:**
-
-- **GitHub API Integration**: Advanced automation and custom workflow development
-- **TypeScript Excellence**: High-quality, type-safe automation and tooling development
-- **DevOps Optimization**: Sophisticated CI/CD and development workflow automation
-- **Open Source Strategy**: Sustainable approaches to project maintenance and community engagement
-
----
-
-## 🚀 Ready to Join the Mission?
-
-### 🎯 Your Impact Starts Today
-
-When you sponsor Marcus, you're not just supporting individual projects—you're investing in:
-
-- **⚡ Developer Productivity**: Tools that save hours every week for thousands of developers
-- **🌟 Ecosystem Growth**: Contributions that strengthen the entire open source community
-- **🔧 Innovation**: Cutting-edge automation and workflow optimization solutions
-- **🤝 Force Multiplier**: A proven system that amplifies your contribution across multiple projects
-- **💡 Thought Leadership**: Supporting technical innovation and best practices development
-
-### 💝 Start Your Sponsorship Journey
-
-<div align="center">
-
-**🎯 [Choose Your Sponsorship Tier →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
-
-**Why Sponsor Marcus?**
-
-- ✅ **Proven Track Record**: 15+ years of professional development, 10+ years OSS contribution
-- ✅ **Real Impact**: Tools and automation used by thousands of developers daily
-- ✅ **Professional Quality**: External configurations, comprehensive testing, maintainable code
-- ✅ **Community Focus**: Force multiplier approach that amplifies your contribution
-- ✅ **Authentic Mission**: Family-driven purpose with consistent long-term commitment
-
-**Getting Started:**
-
-1. **Browse Tiers**: Choose the sponsorship level that matches your goals and budget
-2. **Join Community**: Become part of a growing network of productivity-focused developers
-3. **See Impact**: Watch your support enable continued development and community reinvestment
-4. **Grow Together**: Upgrade tiers as value becomes clear and benefits compound
-
-<div align="center">
-
----
-
-_Thank you for considering sponsorship! Every contribution, regardless of size, makes a meaningful difference in the open source ecosystem._
-
-**Questions?** Feel free to reach out through GitHub or explore the sponsorship tiers to learn more.
-
-<a href="https://github.com/sponsors/marcusrbrown">
-  <img src="https://img.shields.io/github/sponsors/marcusrbrown?style=for-the-badge&logo=github-sponsors&color=ea4aaa" alt="Sponsor Marcus R. Brown">
-</a>
-
-</div>
-
-## 🏆 Proven Track Record: Project Portfolio & Community Impact
-
-### 📊 Community Reach & Impact
-
-**Ecosystem Presence**: Contributing to projects used by thousands of developers daily across diverse technology stacks and industries.
-
-**Problem-Solving Focus**: When I see broken workflows, missing features, or developer pain points, I step in with solutions that benefit the entire community.
-
-**Sustainable Development**: Balancing family priorities with meaningful contribution demonstrates long-term commitment and authentic motivation for open source excellence.
-
-### 🎯 Technical Innovation & Standards
-
-**Automation Leadership**: Creating sophisticated automation systems that eliminate repetitive tasks and streamline development workflows.
-
-**Best Practice Implementation**: External configuration strategies, dependency management optimization, and development workflow standardization.
-
-**Community Tools**: Building productivity solutions that save developers significant time while maintaining professional quality standards.
-
-### 🌟 What Sponsors Say About Impact
-
-**Development Team Lead** (Silver Sponsor):
-
-> _"Your automation tools save our team hours every week. The quality and attention to detail is exactly what we need in our development workflow."_
-
-**Senior Engineer** (Gold Sponsor):
-
-> _"Marcus doesn't just build tools—he solves real problems that affect our daily productivity. Supporting him is an investment in our entire ecosystem."_
-
-**Technology Leader** (Platinum Sponsor):
-
-> _"The force multiplier effect is real. Watching Marcus reinvest sponsorship support into other innovative developers creates ripple effects throughout our community."_
-
-### 🚀 Commitment to Excellence
-
-**Consistent Delivery**: Passionate about open source since childhood, with proven track record of sustained contribution across multiple years and diverse projects.
-
-**Family-Driven Mission**: As a father of five, I understand the importance of reliable tools and sustainable development practices that respect both professional commitments and personal priorities.
-
-**Authentic Purpose**: Not building for vanity metrics or personal gain—focused on creating genuine value that improves developer productivity and community sustainability.
-
-<div align="center">
-
-**🌟 [Join These Satisfied Sponsors →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
-
-### �‍👩‍👧‍👦 My Story: Family, Purpose, and Building What Matters
-
-#### From Childhood Passion to Family-Driven Mission
-
-I've been passionate about open source software since I taught myself programming as a kid. What started as curiosity about how things work has evolved into a deep commitment to building tools that make other developers' lives better.
-
-Today, I live in ☀ Arizona with my five wonderful children, balancing the joys and challenges of family life with meaningful contribution to the developer community. This isn't a side hustle or personal project—it's my authentic mission to create sustainable value in the ecosystem that has given me so much.
-
-#### The Fix-It Mentality That Drives Everything
-
-> "If I see something broke, I fix it, that's how I've always been."
-
-This philosophy shapes every contribution I make. When I encounter broken workflows, missing features, or developer pain points, I don't just work around them—I step in to solve them properly. Whether it's adding missing syntax highlighting, fixing installation bugs, or building entirely new automation tools, I approach problems with the mindset of creating lasting solutions.
-
-#### Balancing Family Priorities with Professional Excellence
-
-As a father of five, I understand the importance of:
-
-- **Efficient workflows** that maximize productive time
-- **Reliable tools** that don't break when you need them most
-- **Sustainable practices** that respect both work and family commitments
-- **Quality over quantity** in everything I build and contribute
-
-This family perspective brings authenticity and purpose to my work. I'm not building for vanity metrics or quick wins—I'm focused on creating genuine value that improves how developers work and live.
-
-#### The Force Multiplier Vision
-
-Your sponsorship does more than fund individual projects. It creates a **force multiplier effect** where:
-
-1. **Your investment** supports advanced automation and productivity tools
-2. **Time savings** from my tools benefit thousands of developers daily
-3. **Sponsor reinvestment** flows to other innovative developers and projects
-4. **Community growth** creates sustainable ecosystem improvements for everyone
-
-When you sponsor me, you're not just supporting one developer—you're investing in a philosophy of mutual support and ecosystem sustainability that amplifies your impact across the entire community.
-
-#### Why This Mission Matters
-
-In a world where developer productivity directly impacts innovation, the tools and systems we build today determine what's possible tomorrow. By supporting automation, fixing broken workflows, and reinvesting in other developers, we create compounding benefits that extend far beyond any individual contribution.
-
-Your sponsorship helps ensure that the open source ecosystem remains vibrant, innovative, and accessible to developers at every stage of their journey—from kids teaching themselves to code (like I once was) to senior professionals building the next generation of tools.
-
-### 🙇🏽 Thank You
-
-I appreciate your sponsorship! Thank you for helping me to realize my goals and remain active in the community.
-
----
-
-## 🚀 Join the Foundation: Help Build Sustainable Open Source
-
-### 🎯 Current Goal: 15 Monthly Sponsors
-
-Building the foundation for long-term ecosystem impact
-
-Right now, we're building something special—a sustainable model where sponsor support creates ripple effects throughout the developer community. With each new sponsor, we get closer to:
-
-- **Dedicated time** for advanced automation tool development
-- **Increased capacity** for cross-project contributions and bug fixes
-- **Enhanced force multiplier** supporting more innovative developers
-- **Sustained commitment** to ecosystem improvement
-
-### ⏰ Why Join Now?
-
-**Early Supporters Get Maximum Recognition**: As we grow the sponsor community, early supporters receive enhanced visibility and recognition as foundational members.
-
-**Direct Impact on Project Direction**: With fewer sponsors, your input carries more weight in determining which tools get built and which developers receive force multiplier support.
-
-**Established Value Before Growth**: Current sponsors benefit from personal attention and direct communication that becomes more challenging as the community scales.
-
-### 🌱 The Growth Trajectory
-
-**Today**: Individual attention, direct communication, personalized automation recommendations
-
-**Next 6 Months**: Expanded tool development, systematic ecosystem contributions, broader force multiplier impact
-
-**Future Vision**: Self-sustaining ecosystem where sponsor investments create compounding benefits for thousands of developers
-
-Join now to be part of this growth story from the beginning.
-
-<div align="center">
-
-**🎯 [Become a Foundational Sponsor →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
-
----
-
-<div align="center"><span title="Marcus singing karaoke in SLC after React Rally circa August 2016"><img src="https://www.dropbox.com/s/45saqar4vwiow1q/IMG_2273.JPG?dl=0&raw=1" alt="Marcus singing karaoke" width="25%" /></span></div>
-<div align="center"><span title="✌🏽 & ❤️"><em>You've got to love life to live it.</em></span></div>
-
 ---
 
 <div align="center">
 
-## 🎯 Ready to Make an Impact?
-
-### Join the community of developers investing in automation, productivity, and ecosystem sustainability
-
-**Choose your contribution level and start making a difference today:**
-
-<br>
-
-<a href="https://github.com/sponsors/marcusrbrown">
-  <img src="https://img.shields.io/github/sponsors/marcusrbrown?style=for-the-badge&logo=github-sponsors&label=Sponsor%20Marcus&color=EA4AAA" alt="Sponsor Marcus Brown" width="280">
-</a>
-
-<br>
-
-✅ Start with any tier • ✅ Upgrade anytime • ✅ Cancel anytime • ✅ Immediate benefit access
-
-<br>
-
-<details>
-<summary><strong>🤔 Still deciding? Quick value summary:</strong></summary>
-
-- **🥉 Bronze ($1-4)**: Recognition + force multiplier impact
-- **🥈 Silver ($5-9)**: Early access + development insights
-- **🥇 Gold ($10-24)**: Direct communication + priority support
-- **🏆 Platinum ($25-99)**: Expert consultation + strategic partnership
-- **💎 Diamond ($100+)**: Premium partnership + custom development
-
-_Every contribution creates a force multiplier effect supporting the broader developer ecosystem._
-
-</details>
-
-<br>
-
-### 🚀 Questions? Let's Connect
-
-Have questions about sponsorship benefits or want to discuss custom arrangements? Feel free to reach out!
-
-📧 **Contact**: [GitHub Issues](https://github.com/marcusrbrown/marcusrbrown/issues/new) • [GitHub Discussions](https://github.com/marcusrbrown/marcusrbrown/discussions) 🐦 **Follow**: [@marcusrbrown](https://github.com/marcusrbrown) for updates and announcements
-
----
-
-**🌟 Join 1 developers already making a difference**
-
-</div>
-
-<!-- Links referenced throughout the document -->
-
-[add features]: https://github.com/search?q=author%3Amarcusrbrown+type%3Apr+is%3Amerged
-[participate in bounties]: https://github.com/search?q=author%3Amarcusrbrown+label%3Abounty
-[fix bugs]: https://github.com/search?q=author%3Amarcusrbrown+type%3Aissue+is%3Aclosed
-
-<br>
-
-Thank you for supporting open source innovation and developer productivity tools! 🙏
+**[Sponsor →](https://github.com/sponsors/marcusrbrown)**
 
 </div>

--- a/SPONSORME.md
+++ b/SPONSORME.md
@@ -8,7 +8,7 @@ I maintain open source developer tooling. If you use what I build, sponsorship k
 
 **[Sponsor on GitHub →](https://github.com/sponsors/marcusrbrown)**
 
-<small><em>Active sponsors: 0</em> · Goal: 15 monthly sponsors (0.0%)</small>
+<small><em>Active sponsors: 1</em> · Goal: 15 monthly sponsors (1.3%)</small>
 
 </div>
 
@@ -38,11 +38,11 @@ GitHub Sponsors lets you pick any amount. Three rough buckets if you want a refe
 
 <div align="center">
 
-| Tier               | Amount      | What you get                                                                                         |
-| :----------------- | :---------- | :--------------------------------------------------------------------------------------------------- |
-| **🥉 Bronze**      | $1 – $4/mo  | Listed below as a supporter. Helps cover hosting & domains.                                          |
-| **🥈 Silver**      | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time.                                             |
-| **🥇 Gold**        | $25+/mo     | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest.     |
+| Tier | Amount | What you get |
+| :-- | :-- | :-- |
+| **🥉 Bronze** | $1 – $4/mo | Listed below as a supporter. Helps cover hosting & domains. |
+| **🥈 Silver** | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time. |
+| **🥇 Gold** | $25+/mo | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest. |
 
 </div>
 
@@ -53,21 +53,67 @@ I'm not running a consulting business through GitHub Sponsors. No monthly calls 
 
 ### Funding goal
 
-*No active funding goals at this time.*
+#### Coffee Fund
+
+Support my daily coding fuel ☕
+
+**Target:** $50/month • **Progress:** 2.0%
+
+```
+░░░░░░░░░░░░░░░░░░░░ 2.0%
+```
+
+<div align="right"><small><em>$1 of $50 monthly goal</em></small></div>
+
+#### Open Source Maintenance
+
+Dedicated time for maintaining and improving open source projects
+
+**Target:** $200/month • **Progress:** 1.0%
+
+```
+░░░░░░░░░░░░░░░░░░░░ 1.0%
+```
+
+<div align="right"><small><em>$2 of $200 monthly goal</em></small></div>
+
+#### Development Tools & Services
+
+Premium tools and cloud services for better development experience
+
+**Target:** $100/month • **Progress:** 1.0%
+
+```
+░░░░░░░░░░░░░░░░░░░░ 1.0%
+```
+
+<div align="right"><small><em>$1 of $100 monthly goal</em></small></div>
 
 <div align="center">
 
-| **Total Monthly Support** |    **Active Goals**    |       **Overall Progress**       |
-| :-----------------------: | :--------------------: | :------------------------------: |
-| **$0** | **0** | **0.0%** |
+| **Total Monthly Support** | **Active Goals** | **Overall Progress** |
+| :-----------------------: | :--------------: | :------------------: |
+|          **$1**           |      **3**       |       **1.3%**       |
 
 </div>
 
-<small><em>Last updated: May 23, 2026</em></small>
+<small><em>Last updated: May 24, 2026</em></small>
 
 ### Supporters
 
-*No sponsors to display at this time. Be the first to support this project!*
+#### 🥉 Bronze Sponsors
+
+<div align="center">
+
+<a href="https://github.com/thejustinwalsh" title="Justin Walsh">
+  <img src="https://avatars.githubusercontent.com/u/72912?u=f8701578b439d99673c3acbc30954c42d27146dd&v=4" width="60" height="60" alt="Justin Walsh" style="border-radius: 50%; margin: 5px;">
+</a>
+
+</div>
+
+<div align="center">
+<small><em>1 supporters contributing $1+ per month</em></small>
+</div>
 
 <!-- END:sponsor-tracker -->
 

--- a/SPONSORME.md
+++ b/SPONSORME.md
@@ -8,7 +8,7 @@ I maintain open source developer tooling. If you use what I build, sponsorship k
 
 **[Sponsor on GitHub →](https://github.com/sponsors/marcusrbrown)**
 
-<small><em>Active sponsors: 0</em> · Goal: 15 monthly sponsors (0.0%)</small>
+<small><em>Active sponsors: 1</em> · Goal: 15 monthly sponsors (1.3%)</small>
 
 </div>
 
@@ -42,21 +42,67 @@ I'm not running a consulting business through this. No monthly calls promised, n
 
 ### Funding goal
 
-*No active funding goals at this time.*
+#### Coffee Fund
+
+Support my daily coding fuel ☕
+
+**Target:** $50/month • **Progress:** 2.0%
+
+```
+░░░░░░░░░░░░░░░░░░░░ 2.0%
+```
+
+<div align="right"><small><em>$1 of $50 monthly goal</em></small></div>
+
+#### Open Source Maintenance
+
+Dedicated time for maintaining and improving open source projects
+
+**Target:** $200/month • **Progress:** 1.0%
+
+```
+░░░░░░░░░░░░░░░░░░░░ 1.0%
+```
+
+<div align="right"><small><em>$2 of $200 monthly goal</em></small></div>
+
+#### Development Tools & Services
+
+Premium tools and cloud services for better development experience
+
+**Target:** $100/month • **Progress:** 1.0%
+
+```
+░░░░░░░░░░░░░░░░░░░░ 1.0%
+```
+
+<div align="right"><small><em>$1 of $100 monthly goal</em></small></div>
 
 <div align="center">
 
-| **Total Monthly Support** |    **Active Goals**    |       **Overall Progress**       |
-| :-----------------------: | :--------------------: | :------------------------------: |
-| **$0** | **0** | **0.0%** |
+| **Total Monthly Support** | **Active Goals** | **Overall Progress** |
+| :-----------------------: | :--------------: | :------------------: |
+|          **$1**           |      **3**       |       **1.3%**       |
 
 </div>
 
-<small><em>Last updated: May 23, 2026</em></small>
+<small><em>Last updated: May 24, 2026</em></small>
 
 ### Supporters
 
-*No sponsors to display at this time. Be the first to support this project!*
+#### 🥉 Bronze Sponsors
+
+<div align="center">
+
+<a href="https://github.com/thejustinwalsh" title="Justin Walsh">
+  <img src="https://avatars.githubusercontent.com/u/72912?u=f8701578b439d99673c3acbc30954c42d27146dd&v=4" width="60" height="60" alt="Justin Walsh" style="border-radius: 50%; margin: 5px;">
+</a>
+
+</div>
+
+<div align="center">
+<small><em>1 supporters contributing $1+ per month</em></small>
+</div>
 
 <!-- END:sponsor-tracker -->
 

--- a/SPONSORME.md
+++ b/SPONSORME.md
@@ -8,7 +8,7 @@ I maintain open source developer tooling. If you use what I build, sponsorship k
 
 **[Sponsor on GitHub →](https://github.com/sponsors/marcusrbrown)**
 
-<small><em>Active sponsors: 1</em> · Goal: 15 monthly sponsors (1.3%)</small>
+<small><em>Active sponsors: 0</em> · Goal: 15 monthly sponsors (0.0%)</small>
 
 </div>
 
@@ -16,12 +16,11 @@ I maintain open source developer tooling. If you use what I build, sponsorship k
 
 ### What I work on
 
-Principal engineer & architect, shipping since 2004. Current focus: agent-native systems, developer tooling, and open source maintenance.
+Principal engineer & architect with 22 years in software. Current focus: agent-native systems, developer tooling, and open source maintenance.
 
 - **[bfra-me/works](https://github.com/bfra-me/works)** — TypeScript tooling configs (ESLint, Prettier, tsconfig presets) used across my projects and a handful of others
 - **[marcusrbrown/systematic](https://github.com/marcusrbrown/systematic)** — Structured engineering workflows for OpenCode
-- **[fro-bot/agent](https://github.com/fro-bot/agent)** — Background-agent harness for delegated work in OpenCode
-- **[ps2dev/ps2sdk](https://github.com/ps2dev/ps2sdk)** — Long-term contributor & maintainer (PlayStation 2 homebrew SDK, 1.1k+ stars)
+- **[fro-bot/agent](https://github.com/fro-bot/agent)** — Deployable agent harness with first-class GitHub and Discord support
 - **[marcusrbrown/.dotfiles](https://github.com/marcusrbrown/.dotfiles)** — Reproducible dev environment configuration
 
 Plus issue triage, PRs, and reviews across the projects I depend on.
@@ -32,88 +31,32 @@ Plus issue triage, PRs, and reviews across the projects I depend on.
 - Faster bug-fix turnaround on the projects sponsors actually use
 - Continued contribution to the upstream projects I rely on
 
-### Tiers
+### How sponsorship works
 
-GitHub Sponsors lets you pick any amount. Three rough buckets if you want a reference point:
+GitHub Sponsors lets you pick any amount. Sponsors are recognized in the section below, classified into tiers by GitHub.
 
-<div align="center">
-
-| Tier | Amount | What you get |
-| :-- | :-- | :-- |
-| **🥉 Bronze** | $1 – $4/mo | Listed below as a supporter. Helps cover hosting & domains. |
-| **🥈 Silver** | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time. |
-| **🥇 Gold** | $25+/mo | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest. |
-
-</div>
-
-I'm not running a consulting business through GitHub Sponsors. No monthly calls promised, no custom dev work, no logo placement. If you need any of that, [contact me directly](https://github.com/marcusrbrown).
+I'm not running a consulting business through this. No monthly calls promised, no custom dev work, no logo placement, no SLA. If you need any of that, [contact me directly](https://github.com/marcusrbrown).
 
 <!-- START:sponsor-tracker -->
 <!-- This section is dynamically populated with sponsor data -->
 
 ### Funding goal
 
-#### Coffee Fund
-
-Support my daily coding fuel ☕
-
-**Target:** $50/month • **Progress:** 2.0%
-
-```
-░░░░░░░░░░░░░░░░░░░░ 2.0%
-```
-
-<div align="right"><small><em>$1 of $50 monthly goal</em></small></div>
-
-#### Open Source Maintenance
-
-Dedicated time for maintaining and improving open source projects
-
-**Target:** $200/month • **Progress:** 1.0%
-
-```
-░░░░░░░░░░░░░░░░░░░░ 1.0%
-```
-
-<div align="right"><small><em>$2 of $200 monthly goal</em></small></div>
-
-#### Development Tools & Services
-
-Premium tools and cloud services for better development experience
-
-**Target:** $100/month • **Progress:** 1.0%
-
-```
-░░░░░░░░░░░░░░░░░░░░ 1.0%
-```
-
-<div align="right"><small><em>$1 of $100 monthly goal</em></small></div>
+*No active funding goals at this time.*
 
 <div align="center">
 
-| **Total Monthly Support** | **Active Goals** | **Overall Progress** |
-| :-----------------------: | :--------------: | :------------------: |
-|          **$1**           |      **3**       |       **1.3%**       |
+| **Total Monthly Support** |    **Active Goals**    |       **Overall Progress**       |
+| :-----------------------: | :--------------------: | :------------------------------: |
+| **$0** | **0** | **0.0%** |
 
 </div>
 
-<small><em>Last updated: May 24, 2026</em></small>
+<small><em>Last updated: May 23, 2026</em></small>
 
 ### Supporters
 
-#### 🥉 Bronze Sponsors
-
-<div align="center">
-
-<a href="https://github.com/thejustinwalsh" title="Justin Walsh">
-  <img src="https://avatars.githubusercontent.com/u/72912?u=f8701578b439d99673c3acbc30954c42d27146dd&v=4" width="60" height="60" alt="Justin Walsh" style="border-radius: 50%; margin: 5px;">
-</a>
-
-</div>
-
-<div align="center">
-<small><em>1 supporters contributing $1+ per month</em></small>
-</div>
+*No sponsors to display at this time. Be the first to support this project!*
 
 <!-- END:sponsor-tracker -->
 

--- a/templates/SPONSORME.tpl.md
+++ b/templates/SPONSORME.tpl.md
@@ -16,12 +16,11 @@ I maintain open source developer tooling. If you use what I build, sponsorship k
 
 ### What I work on
 
-Principal engineer & architect, shipping since 2004. Current focus: agent-native systems, developer tooling, and open source maintenance.
+Principal engineer & architect with 22 years in software. Current focus: agent-native systems, developer tooling, and open source maintenance.
 
 - **[bfra-me/works](https://github.com/bfra-me/works)** — TypeScript tooling configs (ESLint, Prettier, tsconfig presets) used across my projects and a handful of others
 - **[marcusrbrown/systematic](https://github.com/marcusrbrown/systematic)** — Structured engineering workflows for OpenCode
-- **[fro-bot/agent](https://github.com/fro-bot/agent)** — Background-agent harness for delegated work in OpenCode
-- **[ps2dev/ps2sdk](https://github.com/ps2dev/ps2sdk)** — Long-term contributor & maintainer (PlayStation 2 homebrew SDK, 1.1k+ stars)
+- **[fro-bot/agent](https://github.com/fro-bot/agent)** — Deployable agent harness with first-class GitHub and Discord support
 - **[marcusrbrown/.dotfiles](https://github.com/marcusrbrown/.dotfiles)** — Reproducible dev environment configuration
 
 Plus issue triage, PRs, and reviews across the projects I depend on.
@@ -32,21 +31,11 @@ Plus issue triage, PRs, and reviews across the projects I depend on.
 - Faster bug-fix turnaround on the projects sponsors actually use
 - Continued contribution to the upstream projects I rely on
 
-### Tiers
+### How sponsorship works
 
-GitHub Sponsors lets you pick any amount. Three rough buckets if you want a reference point:
+GitHub Sponsors lets you pick any amount. Sponsors are recognized in the section below, classified into tiers by GitHub.
 
-<div align="center">
-
-| Tier | Amount | What you get |
-| :-- | :-- | :-- |
-| **🥉 Bronze** | $1 – $4/mo | Listed below as a supporter. Helps cover hosting & domains. |
-| **🥈 Silver** | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time. |
-| **🥇 Gold** | $25+/mo | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest. |
-
-</div>
-
-I'm not running a consulting business through GitHub Sponsors. No monthly calls promised, no custom dev work, no logo placement. If you need any of that, [contact me directly](https://github.com/marcusrbrown).
+I'm not running a consulting business through this. No monthly calls promised, no custom dev work, no logo placement, no SLA. If you need any of that, [contact me directly](https://github.com/marcusrbrown).
 
 <!-- START:sponsor-tracker -->
 <!-- This section is dynamically populated with sponsor data -->

--- a/templates/SPONSORME.tpl.md
+++ b/templates/SPONSORME.tpl.md
@@ -1,175 +1,57 @@
 <!--markdownlint-disable-->
 
-## 🛠️ The Automation Expert Who Builds the Tools That Save You Hours Every Week
+## Sponsor Marcus R. Brown
 
-### Supporting the developer who fixes what's broken in the ecosystem you depend on
-
-I'm Marcus R. Brown, and I create developer productivity tools, solve complex automation challenges, and contribute meaningfully to the open source projects that power your daily work. When you sponsor me, you're not just funding individual projects—you're unlocking a **force multiplier** that amplifies your impact across the entire developer community.
+I maintain open source developer tooling. If you use what I build, sponsorship keeps me funded to keep it working.
 
 <div align="center">
 
-**🎯 [Sponsor Marcus →](https://github.com/sponsors/marcusrbrown)**
+**[Sponsor on GitHub →](https://github.com/sponsors/marcusrbrown)**
 
-</div>
-
-<div align="center">
-<small><em>Join TOTAL_SPONSOR_COUNT developers already investing in productivity and ecosystem growth</em></small>
-</div>
-
----
-
-### 💡 Why Sponsor Marcus? Clear Value, Proven Impact
-
-<br />
-
-> #### 🛠️ **Advanced Developer Automation & Productivity**
->
-> I build sophisticated automation systems that eliminate repetitive tasks and streamline development workflows. From GitHub sponsor tracking to badge synchronization, my tools save developers significant time every week.
->
-> #### 🔧 **Active Problem-Solver Across the Ecosystem**
->
-> I don't just maintain my own projects—I actively [add features][], [participate in bounties][], and [fix bugs][] across the open source ecosystem. If something's broken and affecting the community, I step in to solve it.
->
-> #### 🌟 **Force Multiplier Effect**
->
-> Your sponsorship creates a ripple effect: I reinvest sponsor support to back other innovative developers, creating a sustainable cycle that amplifies your contribution throughout the community.
->
-> #### 👨‍👩‍👧‍👦 **Family-Driven Mission with Professional Quality**
->
-> As a father of five balancing family priorities with meaningful contribution, I bring both authentic purpose and professional development standards to everything I build.
-
-<div align="center">
-
-**🌟 [See Sponsorship Tiers →](https://github.com/sponsors/marcusrbrown)**
+<small><em>Active sponsors: TOTAL_SPONSOR_COUNT</em> · Goal: 15 monthly sponsors (OVERALL_PROGRESS_PERCENTAGE%)</small>
 
 </div>
 
 ---
 
-## 🎯 Sponsor Benefits: Clear Value for Every Contribution Level
+### What I work on
 
-### 🥉 Bronze Tier ($1-4): Community Recognition & Appreciation
+Principal engineer & architect, shipping since 2004. Current focus: agent-native systems, developer tooling, and open source maintenance.
 
-**Perfect for expressing gratitude and joining the mission with minimal commitment**
+- **[bfra-me/works](https://github.com/bfra-me/works)** — TypeScript tooling configs (ESLint, Prettier, tsconfig presets) used across my projects and a handful of others
+- **[marcusrbrown/systematic](https://github.com/marcusrbrown/systematic)** — Structured engineering workflows for OpenCode
+- **[fro-bot/agent](https://github.com/fro-bot/agent)** — Background-agent harness for delegated work in OpenCode
+- **[ps2dev/ps2sdk](https://github.com/ps2dev/ps2sdk)** — Long-term contributor & maintainer (PlayStation 2 homebrew SDK, 1.1k+ stars)
+- **[marcusrbrown/.dotfiles](https://github.com/marcusrbrown/.dotfiles)** — Reproducible dev environment configuration
 
-- ✅ **Public Recognition**: Your profile featured as a valued community supporter
-- ✅ **Monthly Updates**: Stay informed about project progress and new developments
-- ✅ **Community Membership**: Join a growing network of productivity-focused developers
-- ✅ **Force Multiplier Impact**: Your contribution helps sponsor other innovative developers
+Plus issue triage, PRs, and reviews across the projects I depend on.
 
-**ROI**: Every dollar amplifies across multiple projects and developers in the ecosystem
+### What sponsorship funds
 
----
+- Time on the tooling above instead of squeezing it between contracts
+- Faster bug-fix turnaround on the projects sponsors actually use
+- Continued contribution to the upstream projects I rely on
 
-### 🥈 Silver Tier ($5-9): Early Access & Development Insights
+### Tiers
 
-**Ideal for developers who regularly use automation tools and want to stay ahead**
-
-- ✅ **Everything in Bronze**, plus:
-- ⭐ **Early Access**: First look at new productivity tools and automation systems
-- ⭐ **Development Insights**: Behind-the-scenes content on problem-solving approaches
-- ⭐ **Priority Recognition**: Enhanced visibility in sponsor showcases
-- ⭐ **Technical Content**: Exclusive tips on advanced development practices
-
-**ROI**: Save 2-3 hours monthly through early access to time-saving tools and techniques
-
----
-
-### 🥇 Gold Tier ($10-24): Direct Communication & Priority Support
-
-**Perfect for professional developers seeking networking and technical guidance**
-
-- ✅ **Everything in Silver**, plus:
-- 🌟 **Direct Communication**: Monthly Q&A access for technical questions
-- 🌟 **Feature Input**: Priority consideration for tool features and improvements
-- 🌟 **Professional Networking**: Connect with other Gold+ sponsors in developer community
-- 🌟 **Custom Insights**: Personalized automation recommendations for your workflow
-
-**ROI**: Professional networking value plus personalized efficiency improvements worth 10x the investment
-
----
-
-### 🏆 Platinum Tier ($25-99): Expert Consultation & Strategic Partnership
-
-**Ideal for senior developers and companies seeking strategic technical guidance**
-
-- ✅ **Everything in Gold**, plus:
-- 💎 **Monthly Consultation**: 30-minute monthly video call for technical strategy and guidance
-- 💎 **Custom Content**: Personalized automation scripts and workflow optimization recommendations
-- 💎 **Strategic Partnership**: Input on major technical decisions and project direction
-- 💎 **Executive Recognition**: Featured prominently as a key strategic partner
-- 💎 **Priority Development**: Custom feature development for high-value requests
-
-**ROI**: Executive-level technical guidance worth $200+ monthly plus strategic networking opportunities
-
----
-
-### 💎 Diamond Tier ($100+): Premium Partnership & Custom Development
-
-**For organizations and individuals seeking comprehensive technical partnership**
-
-- ✅ **Everything in Platinum**, plus:
-- 🔥 **Dedicated Support**: Priority response to technical questions and challenges
-- 🔥 **Custom Development**: Quarterly custom tool/script development for your specific needs
-- 🔥 **Advisory Partnership**: Ongoing strategic technical advisory and consultation
-- 🔥 **Exclusive Access**: Early access to all tools, private Discord channel, direct messaging
-- 🔥 **Recognition & Branding**: Logo placement and premium sponsor showcase across projects
-- 🔥 **Speaking Opportunities**: Conference/meetup speaking collaboration and content partnership
-
-**ROI**: Comprehensive technical partnership delivering custom solutions worth $1000+ annually
+GitHub Sponsors lets you pick any amount. Three rough buckets if you want a reference point:
 
 <div align="center">
 
-**🚀 [Choose Your Tier →](https://github.com/sponsors/marcusrbrown)**
+| Tier               | Amount      | What you get                                                                                         |
+| :----------------- | :---------- | :--------------------------------------------------------------------------------------------------- |
+| **🥉 Bronze**      | $1 – $4/mo  | Listed below as a supporter. Helps cover hosting & domains.                                          |
+| **🥈 Silver**      | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time.                                             |
+| **🥇 Gold**        | $25+/mo     | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest.     |
 
 </div>
 
----
-
-## 👨‍👩‍👧‍👦 My Story: From Childhood Passion to Force Multiplier Mission
-
-### The Fix-It Mentality That Drives Everything
-
-> "If I see something broke, I fix it. If it can be automated, I automate it. If it helps developers, I share it."
-
-I've been passionate about open source software since I taught myself programming as a kid. What started as curiosity about how things work has evolved into a deep commitment to building tools that make other developers' lives better.
-
-Today, I live in ☀ Arizona with my five wonderful children, balancing the joys and challenges of family life with meaningful contribution to the developer community. This isn't a side hustle or personal project—it's my authentic mission to create sustainable value in the ecosystem that has given me so much.
-
-### Why Family Balance Creates Better Tools
-
-As a father of five, I understand the importance of:
-
-- **Efficient workflows** that maximize productive time when you have it
-- **Reliable tools** that don't break when you need them most
-- **Sustainable practices** that respect both work and family commitments
-- **Quality over quantity** in everything I build and contribute
-
-This family perspective brings authenticity and purpose to my work. I'm not building for vanity metrics or quick wins—I'm focused on creating genuine value that improves how developers work and live.
-
-### The Force Multiplier Vision
-
-Your sponsorship does more than fund individual projects. It creates a **force multiplier effect** where:
-
-1. **Your investment** supports advanced automation and productivity tools
-2. **Time savings** from my tools benefit thousands of developers daily
-3. **Sponsor reinvestment** flows to other innovative developers and projects
-4. **Community growth** creates sustainable ecosystem improvements for everyone
-
-When you sponsor me, you're not just supporting one developer—you're investing in a philosophy of mutual support and ecosystem sustainability that amplifies your impact across the entire community.
-
-<div align="center">
-
-**💝 [Join the Mission →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
+I'm not running a consulting business through GitHub Sponsors. No monthly calls promised, no custom dev work, no logo placement. If you need any of that, [contact me directly](https://github.com/marcusrbrown).
 
 <!-- START:sponsor-tracker -->
-<!-- This section will be dynamically populated with sponsor data -->
+<!-- This section is dynamically populated with sponsor data -->
 
-## 📊 Progress Tracker
-
-### 🎯 Funding Goals
+### Funding goal
 
 <!-- FUNDING_GOAL_ITEM_START -->
 
@@ -179,15 +61,13 @@ GOAL_DESCRIPTION
 
 **Target:** $GOAL_TARGET_AMOUNT/month • **Progress:** GOAL_PROGRESS_PERCENTAGE%
 
-```
+```text
 GOAL_PROGRESS_BAR
 ```
 
 <div align="right"><small><em>GOAL_CURRENT_AMOUNT of $GOAL_TARGET_AMOUNT monthly goal</em></small></div>
 
 <!-- FUNDING_GOAL_ITEM_END -->
-
-### 📈 Monthly Funding Overview
 
 <div align="center">
 
@@ -197,15 +77,13 @@ GOAL_PROGRESS_BAR
 
 </div>
 
-_Last updated: LAST_UPDATED_DATE_
+<small><em>Last updated: LAST_UPDATED_DATE</em></small>
 
-## 🙏 Sponsor Recognition
-
-### 💎 Our Amazing Supporters
+### Supporters
 
 <!-- TIER_SECTION_START -->
 
-#### TIER_ICON TIER_NAME Sponsors
+#### TIER_ICON TIER_NAME
 
 <div align="center">
 
@@ -217,454 +95,14 @@ _Last updated: LAST_UPDATED_DATE_
 
 </div>
 
-<div align="center">
-<small><em>TIER_SPONSOR_COUNT supporters contributing $TIER_MIN_AMOUNT+ per month</em></small>
-</div>
-
 <!-- TIER_SECTION_END -->
-
-### 🎉 Special Thanks
-
-<div align="center">
-<em>Thank you to all TOTAL_SPONSOR_COUNT sponsors for your incredible support!</em><br>
-<small>Your contributions help maintain and improve open source projects that benefit the entire community.</small>
-</div>
-
----
-
-<div align="center">
-<strong>💝 Want to join these amazing people?</strong><br>
-<a href="https://github.com/sponsors/marcusrbrown">
-  <img src="https://img.shields.io/github/sponsors/marcusrbrown?style=for-the-badge&logo=github-sponsors" alt="Sponsor @marcusrbrown">
-</a>
-</div>
-
-## 📈 Impact Metrics
-
-### 🎯 Community Impact
-
-<div align="center">
-
-| Metric                       |           Value           |
-| :--------------------------- | :-----------------------: |
-| **💰 Total Monthly Support** | **TOTAL_MONTHLY_AMOUNT**  |
-| **👥 Active Sponsors**       |  **TOTAL_SPONSOR_COUNT**  |
-| **🏆 Highest Tier**          |   **HIGHEST_TIER_NAME**   |
-| **📊 Average Contribution**  | **AVERAGE_CONTRIBUTION**  |
-| **📅 Supporting Since**      | **EARLIEST_SPONSOR_DATE** |
-
-</div>
-
-### 🏅 Tier Breakdown
-
-<div align="center">
-
-| Tier                      |     Count      | Monthly Total  |      Percentage      |
-| :------------------------ | :------------: | :------------: | :------------------: |
-| 💎 **Diamond** ($100+)    | DIAMOND_COUNT  | DIAMOND_TOTAL  | DIAMOND_PERCENTAGE%  |
-| 🏆 **Platinum** ($25-$99) | PLATINUM_COUNT | PLATINUM_TOTAL | PLATINUM_PERCENTAGE% |
-| 🥇 **Gold** ($10-$24)     |   GOLD_COUNT   |   GOLD_TOTAL   |   GOLD_PERCENTAGE%   |
-| 🥈 **Silver** ($5-$9)     |  SILVER_COUNT  |  SILVER_TOTAL  |  SILVER_PERCENTAGE%  |
-| 🥉 **Bronze** ($1-$4)     |  BRONZE_COUNT  |  BRONZE_TOTAL  |  BRONZE_PERCENTAGE%  |
-
-</div>
-
-### 💫 Growth & Impact
-
-- **📈 Monthly Growth:** MONTHLY_GROWTH_TREND
-- **🎯 Goal Achievement:** GOAL_COMPLETION_RATE of funding goals reached
-- **🚀 Project Velocity:** Sponsor support enables SUPPORTED_PROJECTS_COUNT active projects
-- **🌟 Community Reach:** Contributing to COMMUNITY_SIZE+ developers worldwide
-
-<div align="center">
-<small><em>Statistics last updated: STATS_LAST_UPDATED</em></small>
-</div>
 
 <!-- END:sponsor-tracker -->
 
-## Proven Track Record: Project Portfolio & Community Impact
-
-### 🛠️ Signature Projects & Contributions
-
-> #### GitHub Sponsors Automation System
->
-> **Impact**: Comprehensive sponsor tracking and recognition system used by OSS maintainers **Technologies**: TypeScript, GitHub API, Dynamic template generation **Community Benefit**: Streamlines sponsor management for open source projects
->
-> #### Developer Productivity Tools Suite
->
-> **Impact**: Badge synchronization, profile automation, and development workflow optimization **Technologies**: Advanced GitHub Actions, API integrations, automated workflows **Community Benefit**: Saves developers 5+ hours weekly on repetitive tasks
->
-> #### Cross-Project Ecosystem Contributions
->
-> **Impact**: Active contributor to textproto-grammar, vscode-markdownlint, and 20+ OSS projects **Technologies**: Language servers, VS Code extensions, parsing libraries **Community Benefit**: Bug fixes and features used by thousands of developers daily
-
-### 📊 Community Reach & Developer Ecosystem Impact
-
-<div align="center">
-
-| **Ecosystem Metric**      | **Impact Scale**             | **Community Value**             |
-| :------------------------ | :--------------------------- | :------------------------------ |
-| **🔧 Active Projects**    | **15+ maintained**           | **Tools used by 10,000+ devs**  |
-| **🐛 Issues Resolved**    | **500+ across projects**     | **Developer friction reduced**  |
-| **⚡ Automation Created** | **Hours saved weekly**       | **Productivity multiplied**     |
-| **🤝 OSS Contributions**  | **Multi-year consistency**   | **Ecosystem strengthened**      |
-| **Problem-Solving**       | **Cross-platform expertise** | **Universal developer benefit** |
-
-</div>
-
-### 🎯 Technical Authority & Expertise Validation
-
-**Advanced Technical Skills:**
-
-- **TypeScript & Node.js**: Expert-level automation and API integration development
-- **GitHub API Mastery**: Comprehensive understanding of GitHub's ecosystem and capabilities
-- **DevOps & Automation**: Sophisticated CI/CD pipelines and workflow optimization
-- **Open Source Strategy**: Proven track record of meaningful community contribution
-
-**Professional Development Standards:**
-
-- **External Configuration Strategy**: All tooling configs extend from `@bfra.me/*` packages
-- **Quality Assurance**: Comprehensive testing, linting, and type checking across all projects
-- **Documentation Excellence**: Clear, maintainable codebases with professional documentation
-- **Consistency & Reliability**: Multi-year track record of consistent, quality contributions
-
-**Years of Experience:**
-
-- **15+ Years**: Professional software development and system architecture
-- **10+ Years**: Active open source contribution and community involvement
-- **5+ Years**: Advanced automation and developer productivity specialization
-- **Continuous Learning**: Staying current with evolving technologies and best practices
-
----
-
-## 💬 Community Trust & Recognition
-
-### 🌟 Sponsor Testimonials
-
-<!-- TESTIMONIAL_SECTION_START -->
-<!-- This section will be populated with sponsor feedback as it becomes available -->
-
-> #### Future Testimonials
->
-> _This section will feature testimonials from sponsors as they share their experiences and the value they've received from supporting Marcus's work._
->
-> **Testimonial Categories:**
->
-> - **Tool Impact**: How Marcus's automation saves time and improves workflows
-> - **Community Value**: The broader benefit of supporting ecosystem development
-> - **Professional Quality**: Recognition of technical excellence and reliability
-> - **Force Multiplier**: Stories of how sponsorship creates ripple effects
-
-<!-- TESTIMONIAL_SECTION_END -->
-
-### 🎯 Trust Signals & Community Standing
-
-**GitHub Profile Statistics:**
-
-- **📈 Contribution Graph**: Consistent daily contributions across multiple years
-- **⭐ Repository Impact**: Projects with measurable adoption and community usage
-- **🤝 Collaboration**: Active participation in issues, PRs, and community discussions
-- **🏆 Profile Recognition**: GitHub activity demonstrating long-term commitment
-
-**Open Source Community Involvement:**
-
-- **🌍 Cross-Project Contributions**: Active in diverse projects beyond personal repositories
-- **🔧 Maintenance Leadership**: Maintaining critical tools used by developer community
-- **💡 Innovation**: Creating new solutions for common developer productivity challenges
-- **🎯 Problem-Focused**: Consistent track record of identifying and solving real developer pain points
-
-**Professional Network & Recognition:**
-
-- **👥 Developer Community**: Active engagement with fellow open source contributors
-- **📱 Platform Presence**: Authentic participation in developer community discussions
-- **🎤 Knowledge Sharing**: Contributing expertise through code, documentation, and community interaction
-- **🏅 Peer Recognition**: Respected contributor in TypeScript, automation, and developer tools communities
-
----
-
-## 🎓 Authority & Thought Leadership
-
-### 💡 Innovation & Technical Leadership
-
-**Automation Philosophy:**
-
-> "If I see something broke, I fix it. If it can be automated, I automate it. If it helps developers, I share it."
-
-**Key Innovation Areas:**
-
-- **Developer Productivity**: Creating tools that eliminate repetitive tasks and streamline workflows
-- **GitHub Ecosystem**: Deep expertise in GitHub API, Actions, and platform optimization
-- **Open Source Strategy**: Proven approach to sustainable project maintenance and community building
-- **Force Multiplier Approach**: Understanding how individual contributions create ecosystem-wide benefits
-
-**Technical Thought Leadership:**
-
-- **External Configuration Strategy**: Pioneering approach to maintainable tooling configurations
-- **Automation-First Development**: Implementing comprehensive automation across all development workflows
-- **Community-Driven Quality**: Balancing individual productivity with broader ecosystem contribution
-- **Sustainable Open Source**: Creating systems that support long-term project health and growth
-
-### 🎯 Problem-Solving Expertise
-
-**Proven Approach:**
-
-1. **Identify Real Problems**: Focus on genuine developer pain points with measurable impact
-2. **Create Robust Solutions**: Build reliable, well-tested tools that solve problems completely
-3. **Share & Document**: Make solutions accessible with clear documentation and examples
-4. **Maintain & Improve**: Provide ongoing support and evolution based on community feedback
-5. **Amplify Impact**: Use successful solutions to enable broader community contributions
-
-**Areas of Expertise:**
-
-- **GitHub API Integration**: Advanced automation and custom workflow development
-- **TypeScript Excellence**: High-quality, type-safe automation and tooling development
-- **DevOps Optimization**: Sophisticated CI/CD and development workflow automation
-- **Open Source Strategy**: Sustainable approaches to project maintenance and community engagement
-
----
-
-## 🚀 Ready to Join the Mission?
-
-### 🎯 Your Impact Starts Today
-
-When you sponsor Marcus, you're not just supporting individual projects—you're investing in:
-
-- **⚡ Developer Productivity**: Tools that save hours every week for thousands of developers
-- **🌟 Ecosystem Growth**: Contributions that strengthen the entire open source community
-- **🔧 Innovation**: Cutting-edge automation and workflow optimization solutions
-- **🤝 Force Multiplier**: A proven system that amplifies your contribution across multiple projects
-- **💡 Thought Leadership**: Supporting technical innovation and best practices development
-
-### 💝 Start Your Sponsorship Journey
-
-<div align="center">
-
-**🎯 [Choose Your Sponsorship Tier →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
-
-**Why Sponsor Marcus?**
-
-- ✅ **Proven Track Record**: 15+ years of professional development, 10+ years OSS contribution
-- ✅ **Real Impact**: Tools and automation used by thousands of developers daily
-- ✅ **Professional Quality**: External configurations, comprehensive testing, maintainable code
-- ✅ **Community Focus**: Force multiplier approach that amplifies your contribution
-- ✅ **Authentic Mission**: Family-driven purpose with consistent long-term commitment
-
-**Getting Started:**
-
-1. **Browse Tiers**: Choose the sponsorship level that matches your goals and budget
-2. **Join Community**: Become part of a growing network of productivity-focused developers
-3. **See Impact**: Watch your support enable continued development and community reinvestment
-4. **Grow Together**: Upgrade tiers as value becomes clear and benefits compound
-
-<div align="center">
-
----
-
-_Thank you for considering sponsorship! Every contribution, regardless of size, makes a meaningful difference in the open source ecosystem._
-
-**Questions?** Feel free to reach out through GitHub or explore the sponsorship tiers to learn more.
-
-<a href="https://github.com/sponsors/marcusrbrown">
-  <img src="https://img.shields.io/github/sponsors/marcusrbrown?style=for-the-badge&logo=github-sponsors&color=ea4aaa" alt="Sponsor Marcus R. Brown">
-</a>
-
-</div>
-
-## 🏆 Proven Track Record: Project Portfolio & Community Impact
-
-### 📊 Community Reach & Impact
-
-**Ecosystem Presence**: Contributing to projects used by thousands of developers daily across diverse technology stacks and industries.
-
-**Problem-Solving Focus**: When I see broken workflows, missing features, or developer pain points, I step in with solutions that benefit the entire community.
-
-**Sustainable Development**: Balancing family priorities with meaningful contribution demonstrates long-term commitment and authentic motivation for open source excellence.
-
-### 🎯 Technical Innovation & Standards
-
-**Automation Leadership**: Creating sophisticated automation systems that eliminate repetitive tasks and streamline development workflows.
-
-**Best Practice Implementation**: External configuration strategies, dependency management optimization, and development workflow standardization.
-
-**Community Tools**: Building productivity solutions that save developers significant time while maintaining professional quality standards.
-
-### 🌟 What Sponsors Say About Impact
-
-**Development Team Lead** (Silver Sponsor):
-
-> _"Your automation tools save our team hours every week. The quality and attention to detail is exactly what we need in our development workflow."_
-
-**Senior Engineer** (Gold Sponsor):
-
-> _"Marcus doesn't just build tools—he solves real problems that affect our daily productivity. Supporting him is an investment in our entire ecosystem."_
-
-**Technology Leader** (Platinum Sponsor):
-
-> _"The force multiplier effect is real. Watching Marcus reinvest sponsorship support into other innovative developers creates ripple effects throughout our community."_
-
-### 🚀 Commitment to Excellence
-
-**Consistent Delivery**: Passionate about open source since childhood, with proven track record of sustained contribution across multiple years and diverse projects.
-
-**Family-Driven Mission**: As a father of five, I understand the importance of reliable tools and sustainable development practices that respect both professional commitments and personal priorities.
-
-**Authentic Purpose**: Not building for vanity metrics or personal gain—focused on creating genuine value that improves developer productivity and community sustainability.
-
-<div align="center">
-
-**🌟 [Join These Satisfied Sponsors →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
-
-### �‍👩‍👧‍👦 My Story: Family, Purpose, and Building What Matters
-
-#### From Childhood Passion to Family-Driven Mission
-
-I've been passionate about open source software since I taught myself programming as a kid. What started as curiosity about how things work has evolved into a deep commitment to building tools that make other developers' lives better.
-
-Today, I live in ☀ Arizona with my five wonderful children, balancing the joys and challenges of family life with meaningful contribution to the developer community. This isn't a side hustle or personal project—it's my authentic mission to create sustainable value in the ecosystem that has given me so much.
-
-#### The Fix-It Mentality That Drives Everything
-
-> "If I see something broke, I fix it, that's how I've always been."
-
-This philosophy shapes every contribution I make. When I encounter broken workflows, missing features, or developer pain points, I don't just work around them—I step in to solve them properly. Whether it's adding missing syntax highlighting, fixing installation bugs, or building entirely new automation tools, I approach problems with the mindset of creating lasting solutions.
-
-#### Balancing Family Priorities with Professional Excellence
-
-As a father of five, I understand the importance of:
-
-- **Efficient workflows** that maximize productive time
-- **Reliable tools** that don't break when you need them most
-- **Sustainable practices** that respect both work and family commitments
-- **Quality over quantity** in everything I build and contribute
-
-This family perspective brings authenticity and purpose to my work. I'm not building for vanity metrics or quick wins—I'm focused on creating genuine value that improves how developers work and live.
-
-#### The Force Multiplier Vision
-
-Your sponsorship does more than fund individual projects. It creates a **force multiplier effect** where:
-
-1. **Your investment** supports advanced automation and productivity tools
-2. **Time savings** from my tools benefit thousands of developers daily
-3. **Sponsor reinvestment** flows to other innovative developers and projects
-4. **Community growth** creates sustainable ecosystem improvements for everyone
-
-When you sponsor me, you're not just supporting one developer—you're investing in a philosophy of mutual support and ecosystem sustainability that amplifies your impact across the entire community.
-
-#### Why This Mission Matters
-
-In a world where developer productivity directly impacts innovation, the tools and systems we build today determine what's possible tomorrow. By supporting automation, fixing broken workflows, and reinvesting in other developers, we create compounding benefits that extend far beyond any individual contribution.
-
-Your sponsorship helps ensure that the open source ecosystem remains vibrant, innovative, and accessible to developers at every stage of their journey—from kids teaching themselves to code (like I once was) to senior professionals building the next generation of tools.
-
-### 🙇🏽 Thank You
-
-I appreciate your sponsorship! Thank you for helping me to realize my goals and remain active in the community.
-
----
-
-## 🚀 Join the Foundation: Help Build Sustainable Open Source
-
-### 🎯 Current Goal: 15 Monthly Sponsors
-
-Building the foundation for long-term ecosystem impact
-
-Right now, we're building something special—a sustainable model where sponsor support creates ripple effects throughout the developer community. With each new sponsor, we get closer to:
-
-- **Dedicated time** for advanced automation tool development
-- **Increased capacity** for cross-project contributions and bug fixes
-- **Enhanced force multiplier** supporting more innovative developers
-- **Sustained commitment** to ecosystem improvement
-
-### ⏰ Why Join Now?
-
-**Early Supporters Get Maximum Recognition**: As we grow the sponsor community, early supporters receive enhanced visibility and recognition as foundational members.
-
-**Direct Impact on Project Direction**: With fewer sponsors, your input carries more weight in determining which tools get built and which developers receive force multiplier support.
-
-**Established Value Before Growth**: Current sponsors benefit from personal attention and direct communication that becomes more challenging as the community scales.
-
-### 🌱 The Growth Trajectory
-
-**Today**: Individual attention, direct communication, personalized automation recommendations
-
-**Next 6 Months**: Expanded tool development, systematic ecosystem contributions, broader force multiplier impact
-
-**Future Vision**: Self-sustaining ecosystem where sponsor investments create compounding benefits for thousands of developers
-
-Join now to be part of this growth story from the beginning.
-
-<div align="center">
-
-**🎯 [Become a Foundational Sponsor →](https://github.com/sponsors/marcusrbrown)**
-
-</div>
-
----
-
-<div align="center"><span title="Marcus singing karaoke in SLC after React Rally circa August 2016"><img src="https://www.dropbox.com/s/45saqar4vwiow1q/IMG_2273.JPG?dl=0&raw=1" alt="Marcus singing karaoke" width="25%" /></span></div>
-<div align="center"><span title="✌🏽 & ❤️"><em>You've got to love life to live it.</em></span></div>
-
 ---
 
 <div align="center">
 
-## 🎯 Ready to Make an Impact?
-
-### Join the community of developers investing in automation, productivity, and ecosystem sustainability
-
-**Choose your contribution level and start making a difference today:**
-
-<br>
-
-<a href="https://github.com/sponsors/marcusrbrown">
-  <img src="https://img.shields.io/github/sponsors/marcusrbrown?style=for-the-badge&logo=github-sponsors&label=Sponsor%20Marcus&color=EA4AAA" alt="Sponsor Marcus Brown" width="280">
-</a>
-
-<br>
-
-✅ Start with any tier • ✅ Upgrade anytime • ✅ Cancel anytime • ✅ Immediate benefit access
-
-<br>
-
-<details>
-<summary><strong>🤔 Still deciding? Quick value summary:</strong></summary>
-
-- **🥉 Bronze ($1-4)**: Recognition + force multiplier impact
-- **🥈 Silver ($5-9)**: Early access + development insights
-- **🥇 Gold ($10-24)**: Direct communication + priority support
-- **🏆 Platinum ($25-99)**: Expert consultation + strategic partnership
-- **💎 Diamond ($100+)**: Premium partnership + custom development
-
-_Every contribution creates a force multiplier effect supporting the broader developer ecosystem._
-
-</details>
-
-<br>
-
-### 🚀 Questions? Let's Connect
-
-Have questions about sponsorship benefits or want to discuss custom arrangements? Feel free to reach out!
-
-📧 **Contact**: [GitHub Issues](https://github.com/marcusrbrown/marcusrbrown/issues/new) • [GitHub Discussions](https://github.com/marcusrbrown/marcusrbrown/discussions) 🐦 **Follow**: [@marcusrbrown](https://github.com/marcusrbrown) for updates and announcements
-
----
-
-**🌟 Join TOTAL_SPONSOR_COUNT developers already making a difference**
-
-</div>
-
-<!-- Links referenced throughout the document -->
-
-[add features]: https://github.com/search?q=author%3Amarcusrbrown+type%3Apr+is%3Amerged
-[participate in bounties]: https://github.com/search?q=author%3Amarcusrbrown+label%3Abounty
-[fix bugs]: https://github.com/search?q=author%3Amarcusrbrown+type%3Aissue+is%3Aclosed
-
-<br>
-
-Thank you for supporting open source innovation and developer productivity tools! 🙏
+**[Sponsor →](https://github.com/sponsors/marcusrbrown)**
 
 </div>

--- a/templates/SPONSORME.tpl.md
+++ b/templates/SPONSORME.tpl.md
@@ -38,11 +38,11 @@ GitHub Sponsors lets you pick any amount. Three rough buckets if you want a refe
 
 <div align="center">
 
-| Tier               | Amount      | What you get                                                                                         |
-| :----------------- | :---------- | :--------------------------------------------------------------------------------------------------- |
-| **🥉 Bronze**      | $1 – $4/mo  | Listed below as a supporter. Helps cover hosting & domains.                                          |
-| **🥈 Silver**      | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time.                                             |
-| **🥇 Gold**        | $25+/mo     | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest.     |
+| Tier | Amount | What you get |
+| :-- | :-- | :-- |
+| **🥉 Bronze** | $1 – $4/mo | Listed below as a supporter. Helps cover hosting & domains. |
+| **🥈 Silver** | $5 – $24/mo | Same, with extra visibility. Funds focused tooling time. |
+| **🥇 Gold** | $25+/mo | Same, plus async Q&A on GitHub Discussions for the projects above. No SLA — best-effort, honest. |
 
 </div>
 


### PR DESCRIPTION
## Summary

Three parallel reviews (adversarial / coherence / product-lens) converged on the same verdict: **rewrite, don't polish**. This PR delivers that rewrite.

The previous template made unverifiable claims, promised SaaS-tier deliverables at indie-sponsor prices, used fake testimonials, duplicated entire sections, repeated 'force multiplier' 18 times, and treated GitHub Sponsors like a SaaS subscription product. It was authored before this profile actually had a clear positioning, and it never matched its author's actual voice.

## Why now

This PR is a hard prerequisite for the v0.1 production use of the sync-sponsors-bio skill (merged in #932). Without this rewrite, that skill would publish 30 KB of marketing sludge to the public sponsors profile bio at [github.com/sponsors/marcusrbrown](https://github.com/sponsors/marcusrbrown).

## What the three reviewers found (consolidated)

**Hard blockers** that all three flagged independently:

| Issue | Where it lived | Action taken |
|---|---|---|
| Fabricated scale claims (`10,000+ devs`, `500+ issues resolved`, `$1000+ annual ROI`) | Throughout | Removed entirely |
| Operationally unrealistic commitments (Platinum: `30-min monthly video call`, Diamond: `quarterly custom dev`, `speaking opportunities`, `logo placement`) | Tier descriptions | Removed; replaced with honest 'no SLA, best-effort' language |
| Fake testimonials (`'Development Team Lead (Silver Sponsor)'`, etc.) with no real attribution | "Sponsor Testimonials" section | Section deleted entirely |
| Duplicate "My Story" section (lines 129–160 AND 521–561) | Whole-section duplication | Both removed |
| Duplicate "Proven Track Record" section (lines 285–337 AND 475–513) | Whole-section duplication | Both removed |
| 'Force multiplier' buzzword (18 occurrences with drifting meaning) | Throughout | Removed all 18 |
| 'Father of five' / family-as-marketing repeated 6 times | Throughout | Removed all 6 |
| Self-quote `If I see something broke, I fix it` repeated 3 times with variant phrasings | Throughout | Removed all 3 |
| Stale `15+ Years` claim contradicting README's refreshed `22 years` | Authority section | Removed |
| 13 sponsor CTA buttons scattered throughout | Throughout | Reduced to 2 |
| Broken emoji glyph from encoding damage on line 521 | Heading | Removed with the section |

## Design decisions (from interactive HITL)

- **Tier structure**: Collapsed Bronze/Silver/Gold/Platinum/Diamond → Bronze ($1-4) / Silver ($5-24) / Gold ($25+). The previous 5-tier ladder was indie-grift theater; three honest tiers reflect what GitHub Sponsors actually rewards.
- **Positioning wedge**: 'Maintainer of developer tooling + open source.' Matches the README's refreshed agent-native/tooling framing. Concrete, evidence-first.
- **Personal narrative**: Cut entirely. No family mention, no childhood story, no philosophy quotes, no karaoke photo. Per author's direct/terse voice from AGENTS.md.
- **Evidence-first portfolio**: Named real projects with real descriptions:
  - [bfra-me/works](https://github.com/bfra-me/works) — TypeScript tooling configs
  - [marcusrbrown/systematic](https://github.com/marcusrbrown/systematic) — Engineering workflows for OpenCode
  - [fro-bot/agent](https://github.com/fro-bot/agent) — Background-agent harness
  - [ps2dev/ps2sdk](https://github.com/ps2dev/ps2sdk) — Long-term contributor (1.1k+ stars)
  - [marcusrbrown/.dotfiles](https://github.com/marcusrbrown/.dotfiles) — Reproducible dev environment

## Scope-boundary clarification

Added explicit anti-promise paragraph that the original lacked:

> *I'm not running a consulting business through GitHub Sponsors. No monthly calls promised, no custom dev work, no logo placement. If you need any of that, [contact me directly](https://github.com/marcusrbrown).*

This trades aspirational tier copy for trust. The previous Platinum/Diamond tiers created expectation debt that would publicly fail the first time an over-committed Diamond sponsor expected their quarterly custom dev work.

## Backward-compatibility

- **Dynamic substitution machinery preserved**: `TOTAL_SPONSOR_COUNT`, `OVERALL_PROGRESS_PERCENTAGE`, `LAST_UPDATED_DATE`, `TIER_SECTION_START`/`END`, `SPONSOR_ITEM_START`/`END`, `FUNDING_GOAL_ITEM_START`/`END` all still work. No script changes needed.
- **Zero-sponsor case verified clean**: At the current real count (0 sponsors, 6% of 15-sponsor goal), the rendered output is coherent and inviting without making the absence feel awkward.
- **Tier deletion handled gracefully**: The 5-tier dynamic rendering (Diamond/Platinum/Gold/Silver/Bronze) still substitutes for any existing sponsors — only the static benefit copy changed. The supporter avatars section will render correctly when sponsors land.

## Stats

- Template: 670 → 108 lines (-84%)
- Rendered SPONSORME.md: 684 → 80 lines (-88%)
- CTA buttons: 13 → 2
- 'force multiplier' occurrences: 18 → 0
- 'father of five' / 'family' mentions: 6 → 0
- Fake testimonials: 3 → 0
- Duplicate sections: 2 → 0
- Unverifiable scale claims: all removed

## Verification

- `pnpm lint` clean
- `pnpm sponsors:update` renders cleanly end-to-end against current data
- Zero-sponsor fallback rendering verified
- Placeholder substitution verified working (LAST_UPDATED_DATE, TOTAL_SPONSOR_COUNT, OVERALL_PROGRESS_PERCENTAGE)
- All 80 lines of rendered output read out loud sound like Marcus, not LinkedIn

## What this PR enables

Merging this unblocks the v0.1 first-production-use of the sync-sponsors-bio skill (#932). After merge:

1. Auto-update workflow regenerates SPONSORME.md within ~6h (or instantly on push)
2. Run `pnpm sponsors:bio:sync` (the new skill)
3. Review the populated dashboard form in the browser
4. Click 'Update profile' to publish the rewritten bio to github.com/sponsors/marcusrbrown