### PR TITLE
fix(fro-bot): honor a bare workflow_dispatch prompt regardless of mode

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -629,7 +629,7 @@ jobs:
           IS_SUNDAY_UTC: ${{ env.IS_SUNDAY_UTC || 'false' }}
           PROMPT: >-
             ${{
-              (github.event_name == 'workflow_dispatch' && inputs.mode == 'review' && inputs.prompt)
+              (github.event_name == 'workflow_dispatch' && inputs.prompt)
               || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance' && env.MAINTENANCE_PROMPT)
               || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal' && env.AUTOHEAL_PROMPT)
               || (github.event_name == 'workflow_dispatch' && !inputs.mode && env.AUTOHEAL_PROMPT)


### PR DESCRIPTION
## What

A `workflow_dispatch` that passes only a custom `prompt` (no `mode`) had its prompt silently discarded. The `Run Fro Bot` step only consumed `inputs.prompt` when `inputs.mode == 'review'`, and `mode` defaults to `autoheal` — so a bare-prompt dispatch fell through to the autoheal prompt and ran the wrong task.

This surfaced when a cross-repo goal dispatch (which sends only the universal `prompt` input, since not every repo declares a `mode`) triggered an autoheal run instead of the requested task.

## Fix

Let a non-empty `inputs.prompt` win first for any `workflow_dispatch`, before the mode-based selection:

```diff
-  (github.event_name == 'workflow_dispatch' && inputs.mode == 'review' && inputs.prompt)
+  (github.event_name == 'workflow_dispatch' && inputs.prompt)
```

Same fix landed in sparkle. Behavior when no prompt is supplied is unchanged: maintenance/autoheal still fire by mode, and the separate review-mode input validation step is untouched.